### PR TITLE
add Typescript type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,116 @@
+import { DocumentClient } from "aws-sdk/clients/dynamodb";
+
+type FieldTypes =
+  | "string"
+  | "boolean"
+  | "number"
+  | "list"
+  | "map"
+  | "binary"
+  | "set";
+
+type CoerceTypes = "string" | "boolean" | "number" | "list";
+
+type SetTypes = "string" | "number" | "binary";
+
+type CompositeKeyFieldConfiguration<T> = FieldDefinition<T> & {
+  save?: boolean;
+};
+
+type CompositeKeyFieldDefinition<T> = [
+  string,
+  number,
+  CompositeKeyFieldConfiguration<T>?
+];
+
+interface FieldDefinition<T> {
+  type?: FieldTypes;
+  coerce?: CoerceTypes;
+  default?: (data: T) => any;
+  onUpdate?: boolean;
+  hidden?: boolean;
+  required?: boolean | "always";
+  alias?: keyof T;
+  setType?: SetTypes;
+}
+
+type SchemaDefinition<T> = Record<
+  string,
+  FieldTypes | FieldDefinition<T> | CompositeKeyFieldDefinition<T>
+>;
+
+interface ModelDefinition<T> {
+  table: string;
+  partitionKey: string;
+  sortKey?: string;
+  model?: boolean;
+  timestamps?: boolean;
+  created?: string;
+  modified?: string;
+  schema: SchemaDefinition<T>;
+}
+
+type UpdateNumberOperations =
+  | {
+      $add: number;
+    }
+  | number;
+
+type UpdateArrayOperations<T> =
+  | {
+      $add?: T[];
+      $delete?: T[];
+      $append?: T[];
+      $prepend?: T[];
+      $remove?: T[];
+      [index: number]: T;
+    }
+  | T[];
+
+type UpdateItemObjectField<T> =
+  | {
+      $set:
+        | {
+            [P in keyof T]?: UpdateItemField<T[P]>;
+          }
+        | {
+            [index: string]: any;
+          };
+    }
+  | T;
+
+type UpdateItemField<T> = T extends Array<infer P>
+  ? UpdateArrayOperations<P>
+  : T extends object
+  ? UpdateItemObjectField<T>
+  : T extends number
+  ? UpdateNumberOperations
+  : T;
+
+type UpdateItemWrapper<T> = { [P in keyof T]?: UpdateItemField<T[P]> };
+
+export class Model<T> {
+  constructor(modelName: string, modelDefinition: ModelDefinition<T>);
+
+  put(
+    item: T,
+    custom?: Partial<DocumentClient.PutItemInput>
+  ): DocumentClient.PutItemInput;
+
+  update(
+    item: UpdateItemWrapper<T>,
+    custom?: Partial<DocumentClient.UpdateItemInput>
+  ): DocumentClient.UpdateItemInput;
+
+  get(
+    key: Partial<T>,
+    custom?: DocumentClient.GetItemInput
+  ): DocumentClient.GetItemInput;
+
+  delete(
+    key: Partial<T>,
+    custom?: DocumentClient.DeleteItemInput
+  ): DocumentClient.DeleteItemInput;
+
+  parse(response: DocumentClient.GetItemOutput): T | T[];
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple set of tools for working with Amazon DynamoDB and the DocumentClient.",
   "author": "Jeremy Daly <jeremy@jeremydaly.com>",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest unit",
     "test-ci": "eslint . && jest unit --coverage && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",


### PR DESCRIPTION
Adds Typescript type definitions to this library. Some areas are not as strongly typed as I would like (eg. since both sets and lists are updated as arrays the update object for these exposes operations for both of them). 

One area I'm not sure if the library supports is updating nested maps using the `$set` syntax. The typings will allow the following scenario and provide type support. 

```typescript
import { Model } from 'dynamodb-toolbox';

interface Entity {
    pk: string;
    level1: {
        level2: {
            prop1: number;
            prop2: number[];
        }
    }
}

const model: Model<Entity> = { ... }

const updateParams = model.update({
    pk: 'test',
    level1: {
      $set: {
          level2:  {
              $set: {
                  prop1: { $add: 42 },
                  prop2: { $prepend: [ 1, 2, 3] }
              }
          }
      }
    }
});
```

It would be nice if the library could also handle nested map types using this syntax.

Feel free to hit me up if there are any issues/feedback. Also thanks for making this awesome library 🙏