### PR TITLE
Add TypeScript Definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare module "dynamodb-toolbox" {
     Attributes?: Schema & SchemaBase;
   }
 
-  export class Entity<Schema> {
+  export class Entity<Schema extends { [key in keyof Schema]: SchemaType }> {
     constructor(options: EntityConstructor<Schema>);
 
     // Properties
@@ -144,10 +144,10 @@ declare module "dynamodb-toolbox" {
   }
 
   // Entity
-  interface EntityAttributesConfiguration {
+  interface EntityAttributeConfiguration<Schema> {
     type?: AnyDynamoDBType;
     coerce?: boolean;
-    default?: string | boolean | number | [] | {} | ((data: any) => any); // Value "type" or a function
+    default?: SchemaType | ((data: Schema) => SchemaType); // Value "type" or a function
     onUpdate?: boolean;
     hidden?: boolean;
     required?: boolean | AlwaysOption;
@@ -157,15 +157,16 @@ declare module "dynamodb-toolbox" {
     partitionKey?: boolean | string;
     sortKey?: boolean | string;
   }
-  interface CompositeKeyConfiguration extends EntityAttributesConfiguration {
+  interface CompositeKeyConfiguration<Schema>
+    extends EntityAttributeConfiguration<Schema> {
     type?: DynamoDBStringType | DynamoDBNumberType | DynamoDBBooleanType;
     save?: boolean;
   }
-  type CompositeKey = [
+  type CompositeKey<Schema> = [
     string,
     number,
     (
-      | CompositeKeyConfiguration
+      | CompositeKeyConfiguration<Schema>
       | DynamoDBStringType
       | DynamoDBNumberType
       | DynamoDBBooleanType
@@ -173,7 +174,9 @@ declare module "dynamodb-toolbox" {
   ];
   type EntityAttributes<Schema> = Record<
     keyof Schema,
-    AnyDynamoDBType | EntityAttributesConfiguration | CompositeKey
+    | AnyDynamoDBType
+    | EntityAttributeConfiguration<Schema>
+    | CompositeKey<Schema>
   >;
   interface EntityConstructor<Schema> {
     name: string;
@@ -211,11 +214,18 @@ declare module "dynamodb-toolbox" {
   // Options
   type NoneOption = "none";
   type AllOldOption = "all_old";
-  type AlwaysOption = "allways";
+  type AlwaysOption = "always";
   type UpdatedOldOption = "updated_old";
   type AllNewOption = "all_new";
   type UpdatedNewOption = "updated_new";
   type TotalOption = "total";
   type IndexesOption = "indexes";
   type SizeOption = "size";
+
+  type SchemaType =
+    | string
+    | number
+    | boolean
+    | { [key: string]: SchemaType }
+    | SchemaType[];
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@
 //
 // Improvements:
 // 1. Type Table methods parameters and returns
+// 1bis. Improve sortKey typing and impact on gt, lt, etc.
 // 2. Separate this file in several for better code understanding
 // 3. Improve input/output to methods thanks to "Schema"
 // 4. Improve complex "key" type from update and delete methods
@@ -37,12 +38,52 @@ declare module "dynamodb-toolbox" {
     delete(entity, key, options?, parameters?);
     put(entity, item, options?, parameters?);
     update(entity, key, options?, parameters?);
-    query(partitionKey, options?, parameters?);
-    scan(options?, parameters?);
+    query(
+      partitionKey: string,
+      options?: QueryInputOptions,
+      parameters?
+    ): Promise<any>;
+    scan(options?: ScanInputOptions, parameters?): Promise<any>;
     batchWrite(items, options?, parameters?);
     batchGet(items, options?, parameters?);
   }
 
+  interface ScanInputOptions {
+    index?: string;
+    limit?: number;
+    consistent?: boolean;
+    capacity: string;
+    select: string;
+    filters?: {} | [];
+    attributes?: {} | [];
+    startKey?: {};
+    segments?: number;
+    segment?: number;
+    entity?: string;
+    autoExecute?: boolean;
+    autoParse?: boolean;
+  }
+  interface QueryInputOptions {
+    index?: string;
+    limit?: number;
+    reverse?: boolean;
+    consistent?: boolean;
+    capacity?: string;
+    select?: string;
+    eq?: string;
+    lt?: string;
+    lte?: string;
+    gt?: string;
+    gte?: string;
+    between?: [string, string];
+    beginsWith?: string;
+    filters?: {} | [];
+    attributes?: {} | [];
+    startKey?: {};
+    entity?: string;
+    autoExecute?: boolean;
+    autoParse?: boolean;
+  }
   interface SchemaBase {
     entity: string;
     created: string;
@@ -130,7 +171,11 @@ declare module "dynamodb-toolbox" {
       },
       parameters?
     ): Promise<UpdateOutput<Schema>>;
-    query(partionKey, options?, parameters?);
+    query(
+      partitionKey: string,
+      options?: QueryInputOptions,
+      parameters?
+    ): Promise<any>;
     scan(options?, parameters?);
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,12 @@
+// DynamoDB Toolbox TypeScript Definition
+//
+// Improvements:
+// 1. Type Table methods parameters and returns
+// 2. Separate this file in several for better code understanding
+// 3. Improve input/output to methods thanks to "Schema"
+// 4. Improve complex "key" type from update and delete methods
+// 5. Pass DynamoDB Toolbox to TypeScript :fear:
+
 declare module "dynamodb-toolbox" {
   // Imports
   import {
@@ -22,16 +31,16 @@ declare module "dynamodb-toolbox" {
     autoParse: boolean;
 
     // Methods
-    attribute(...args: any);
-    parse(...args: any);
-    get(...args: any);
-    delete(...args: any);
-    put(...args: any);
-    update(...args: any);
-    query(...args: any);
-    scan(...args: any);
-    batchWrite(...args: any);
-    batchGet(...args: any);
+    attribute(...args: any); // Not documented
+    parse(entity, input, include?);
+    get(entity, key, options?, parameters?);
+    delete(entity, key, options?, parameters?);
+    put(entity, item, options?, parameters?);
+    update(entity, key, options?, parameters?);
+    query(partitionKey, options?, parameters?);
+    scan(options?, parameters?);
+    batchWrite(items, options?, parameters?);
+    batchGet(items, options?, parameters?);
   }
 
   interface SchemaBase {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,210 @@
+declare module "dynamodb-toolbox" {
+  // Imports
+  import {
+    DocumentClient,
+    GetItemOutput,
+    PutItemOutput,
+    DeleteItemOutput,
+  } from "aws-sdk/clients/dynamodb";
+
+  // Exports
+  export class Table {
+    constructor(options: TableConstructor);
+
+    // Properties
+    DocumentClient: DocumentClient;
+    // getters and setters with different types is a no in TS
+    // https://github.com/microsoft/TypeScript/issues/2521
+    get entities(): any;
+    set entities(entity: any);
+    autoExecute: boolean;
+    autoParse: boolean;
+    [entity: string]: Entity<any>;
+
+    // Methods
+    attribute();
+    parse();
+    get();
+    delete();
+    put();
+    update();
+    query();
+    scan();
+    batchWrite();
+    batchGet();
+  }
+
+  interface SchemaBase {
+    type?: string;
+    created?: string;
+    modified?: string;
+  }
+  interface GetOuput<Schema> extends GetItemOutput {
+    Item?: Schema & SchemaBase;
+  }
+  interface PutOutput<Schema> extends PutItemOutput {
+    Attributes?: Schema & SchemaBase;
+  }
+  interface DeleteOutput<Schema> extends DeleteItemOutput {
+    Attributes?: Schema & SchemaBase;
+  }
+  interface UpdateOutput<Schema> {}
+  // Todo: Define UpdateOutput
+  export class Entity<Schema> {
+    constructor(options: EntityConstructor);
+
+    // Properties
+    table: Table;
+    readonly DocumentClient: DocumentClient;
+    autoExecute: boolean;
+    autoParse: boolean;
+    readonly partitionKey: string;
+    readonly sortKey: string;
+
+    // Methods
+    attribute(attribute: string): string;
+    parse(input, include?);
+    get(
+      item: Schema,
+      options?: {
+        consistent?: boolean;
+        capacity?: "none" | "total" | "indexes";
+        attributes?: [] | {};
+        autoExecute?: boolean;
+        autoParse?: boolean;
+      },
+      parameters?
+    ): Promise<GetOuput<Schema>>;
+    delete(
+      key: {},
+      options?: {
+        conditions?: [] | {};
+        capacity?: "none" | "total" | "indexes";
+        metrics?: "none" | "size";
+        returnValues?: "none" | "all_old";
+        autoExecute?: boolean;
+        autoParse?: boolean;
+      },
+      parameters?
+    ): Promise<DeleteOutput<Schema>>;
+    put(
+      item: Schema,
+      options?: {
+        conditions?: [] | {};
+        capacity?: "none" | "total" | "indexes"; // Cannot use DynamoDB type as it's upper-case
+        metrics?: "none" | "size";
+        returnValues?: "none" | "all_old";
+        autoExecute?: boolean;
+        autoParse?: boolean;
+      },
+      parameters?
+    ): Promise<PutOutput<Schema>>;
+    update(
+      key: Schema & { $remove?: string[] }, // Complex part to type
+      options?: {
+        conditions?: [] | {};
+        capacity?: "none" | "total" | "indexes";
+        metrics?: "none" | "size";
+        returnValues?:
+          | "none"
+          | "all_old"
+          | "updated_old"
+          | "all_new"
+          | "updated_new";
+        autoExecute?: boolean;
+        autoParse?: boolean;
+      },
+      parameters?
+    ): Promise<UpdateOutput<Schema>>;
+    query();
+    scan();
+  }
+
+  // Table
+  interface TableAttributes {
+    [attribute: string]: AnyDynamoDBType;
+  }
+  interface Indexes {
+    [index: string]: { partitionKey?: string; sortKey?: string };
+  }
+  interface TableConstructor {
+    name: string;
+    alias?: string;
+    partitionKey: string;
+    sortKey?: string;
+    entityField?: boolean | string;
+    attributes?: TableAttributes;
+    indexes?: Indexes;
+    autoExecute?: boolean;
+    autoParse?: boolean;
+    DocumentClient?: DocumentClient;
+    entities?: {}; // improve - not documented
+  }
+
+  // Entity
+  interface EntityAttributesConfiguration {
+    type?: AnyDynamoDBType;
+    coerce?: boolean;
+    default?: string | boolean | number | [] | {} | ((data: any) => any); // Value "type" or a function
+    onUpdate?: boolean;
+    hidden?: boolean;
+    required?: boolean | "always";
+    alias?: string;
+    map?: string;
+    setType?: DynamoDBStringType | DynamoDBNumberType | DynamoDBBinaryType;
+    partitionKey?: boolean | string;
+    sortKey?: boolean | string;
+  }
+  interface CompositeKeyConfiguration extends EntityAttributesConfiguration {
+    type?: DynamoDBStringType | DynamoDBNumberType | DynamoDBBooleanType;
+    save?: boolean;
+  }
+  type CompositeKey = [
+    string,
+    number,
+    (
+      | CompositeKeyConfiguration
+      | DynamoDBStringType
+      | DynamoDBNumberType
+      | DynamoDBBooleanType
+    )?
+  ];
+  interface EntityAttributes {
+    [attribute: string]:
+      | AnyDynamoDBType
+      | EntityAttributesConfiguration
+      | CompositeKey;
+  }
+  interface EntityConstructor {
+    name: string;
+    timestamps?: boolean;
+    created?: string;
+    modified?: string;
+    createdAlias?: string;
+    modifiedAlias?: string;
+    typeAlias?: string;
+    attributes: EntityAttributes;
+    autoExecute?: boolean;
+    autoParse?: boolean;
+    table?: Table;
+  }
+
+  // Constants
+
+  // DynamoDB
+  type DynamoDBStringType = "string";
+  type DynamoDBBooleanType = "boolean";
+  type DynamoDBNumberType = "number";
+  type DynamoDBListType = "list";
+  type DynamoDBMapType = "map";
+  type DynamoDBBinaryType = "binary";
+  type DynamoDBSetType = "set";
+  type AnyDynamoDBType =
+    | DynamoDBStringType
+    | DynamoDBBooleanType
+    | DynamoDBNumberType
+    | DynamoDBListType
+    | DynamoDBMapType
+    | DynamoDBBinaryType
+    | DynamoDBSetType;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,16 +22,16 @@ declare module "dynamodb-toolbox" {
     autoParse: boolean;
 
     // Methods
-    attribute();
-    parse();
-    get();
-    delete();
-    put();
-    update();
-    query();
-    scan();
-    batchWrite();
-    batchGet();
+    attribute(...args: any);
+    parse(...args: any);
+    get(...args: any);
+    delete(...args: any);
+    put(...args: any);
+    update(...args: any);
+    query(...args: any);
+    scan(...args: any);
+    batchWrite(...args: any);
+    batchGet(...args: any);
   }
 
   interface SchemaBase {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare module "dynamodb-toolbox" {
       item: Schema,
       options?: {
         consistent?: boolean;
-        capacity?: "none" | "total" | "indexes";
+        capacity?: NoneOption | TotalOption | IndexesOption;
         attributes?: [] | {};
         autoExecute?: boolean;
         autoParse?: boolean;
@@ -79,9 +79,9 @@ declare module "dynamodb-toolbox" {
       key: {},
       options?: {
         conditions?: [] | {};
-        capacity?: "none" | "total" | "indexes";
-        metrics?: "none" | "size";
-        returnValues?: "none" | "all_old";
+        capacity?: NoneOption | TotalOption | IndexesOption;
+        metrics?: NoneOption | SizeOption;
+        returnValues?: NoneOption | AllOldOption;
         autoExecute?: boolean;
         autoParse?: boolean;
       },
@@ -91,9 +91,9 @@ declare module "dynamodb-toolbox" {
       item: Schema,
       options?: {
         conditions?: [] | {};
-        capacity?: "none" | "total" | "indexes"; // Cannot use DynamoDB type as it's upper-case
-        metrics?: "none" | "size";
-        returnValues?: "none" | "all_old";
+        capacity?: NoneOption | TotalOption | IndexesOption; // Cannot use DynamoDB type as it's upper-case
+        metrics?: NoneOption | SizeOption;
+        returnValues?: NoneOption | AllOldOption;
         autoExecute?: boolean;
         autoParse?: boolean;
       },
@@ -103,21 +103,21 @@ declare module "dynamodb-toolbox" {
       key: Schema & { $remove?: string[] }, // Complex part to type
       options?: {
         conditions?: [] | {};
-        capacity?: "none" | "total" | "indexes";
-        metrics?: "none" | "size";
+        capacity?: NoneOption | TotalOption | IndexesOption;
+        metrics?: NoneOption | SizeOption;
         returnValues?:
-          | "none"
-          | "all_old"
-          | "updated_old"
-          | "all_new"
-          | "updated_new";
+          | NoneOption
+          | AllOldOption
+          | UpdatedOldOption
+          | AllNewOption
+          | UpdatedNewOption;
         autoExecute?: boolean;
         autoParse?: boolean;
       },
       parameters?
     ): Promise<UpdateOutput<Schema>>;
-    query();
-    scan();
+    query(partionKey, options?, parameters?);
+    scan(options?, parameters?);
   }
 
   // Table
@@ -148,7 +148,7 @@ declare module "dynamodb-toolbox" {
     default?: string | boolean | number | [] | {} | ((data: any) => any); // Value "type" or a function
     onUpdate?: boolean;
     hidden?: boolean;
-    required?: boolean | "always";
+    required?: boolean | AlwaysOption;
     alias?: string;
     map?: string;
     setType?: DynamoDBStringType | DynamoDBNumberType | DynamoDBBinaryType;
@@ -207,4 +207,15 @@ declare module "dynamodb-toolbox" {
     | DynamoDBMapType
     | DynamoDBBinaryType
     | DynamoDBSetType;
+
+  // Options
+  type NoneOption = "none";
+  type AllOldOption = "all_old";
+  type AlwaysOption = "allways";
+  type UpdatedOldOption = "updated_old";
+  type AllNewOption = "all_new";
+  type UpdatedNewOption = "updated_new";
+  type TotalOption = "total";
+  type IndexesOption = "indexes";
+  type SizeOption = "size";
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A simple set of tools for working with Amazon DynamoDB and the DocumentClient.",
   "author": "Jeremy Daly <jeremy@jeremydaly.com>",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jest unit",
     "test-cov": "jest unit --coverage",


### PR DESCRIPTION
@jeremydaly as discussed on Twitter I started the TypeScript definition of v0.2.

One of the things I wanna do is let the developer define its schema as types and pass it as a generic to the lib in order to have the proper return types from any get, put, update, etc.

Still la lot of work to do, but it's a beginning, I think any feedback is useful already! For me not to go in the wrong direction.
What would be a first good definition in term of type quality depth? To go step by step.