### PR TITLE
support false/empty string for eq

### DIFF
--- a/__tests__/expressionBuilder.unit.test.js
+++ b/__tests__/expressionBuilder.unit.test.js
@@ -181,6 +181,18 @@ describe('expressionBuilder',() => {
     expect(result.values).toEqual({ ':attr1': 'b' })
   })
 
+  it(`generates an 'eq' clause with empty/false values`, () => {
+    let result = expressionBuilder({ attr: 'a', eq: false },TestTable,'TestEntity')
+    expect(result.expression).toBe('#attr1 = :attr1')
+    expect(result.names).toEqual({ '#attr1': 'a' })
+    expect(result.values).toEqual({ ':attr1': false })
+
+    result = expressionBuilder({ attr: 'a', eq: "" },TestTable,'TestEntity')
+    expect(result.expression).toBe('#attr1 = :attr1')
+    expect(result.names).toEqual({ '#attr1': 'a' })
+    expect(result.values).toEqual({ ':attr1': "" })
+  })
+
   it(`generates a 'ne' clause`, () => {
     let result = expressionBuilder({ attr: 'a', ne: 'b' },TestTable,'TestEntity')
     expect(result.expression).toBe('#attr1 <> :attr1')

--- a/lib/expressionBuilder.js
+++ b/lib/expressionBuilder.js
@@ -10,7 +10,7 @@
 // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.OperatorsAndFunctions.html
 
 // Import standard error handler
-const { error } = require('./utils')
+const { error, hasValue } = require('./utils')
 const checkAttribute = require('./checkAttribute')
 
 const buildExpression = (exp,table,entity,group=0,level=0) => {
@@ -128,7 +128,7 @@ const parseClause = (_clause,grp,table) => {
 
   // Parse clause operator and value
   let operator, value, f
-  if (eq !== undefined && eq !== null) { value = eq; f = 'eq'; operator = '=' }
+  if (hasValue(eq)) { value = eq; f = 'eq'; operator = '=' }
   if (ne) { value = value ? conditionError(f) : ne; f = 'ne'; operator = '<>' }
   if (_in) { value = value ? conditionError(f) : _in; f = 'in'; operator = 'IN' }
   if (lt) { value = value ? conditionError(f) : lt; f = 'lt'; operator = '<' }

--- a/lib/expressionBuilder.js
+++ b/lib/expressionBuilder.js
@@ -128,7 +128,7 @@ const parseClause = (_clause,grp,table) => {
 
   // Parse clause operator and value
   let operator, value, f
-  if (eq) { value = eq; f = 'eq'; operator = '=' }
+  if (eq !== undefined && eq !== null) { value = eq; f = 'eq'; operator = '=' }
   if (ne) { value = value ? conditionError(f) : ne; f = 'ne'; operator = '<>' }
   if (_in) { value = value ? conditionError(f) : _in; f = 'in'; operator = 'IN' }
   if (lt) { value = value ? conditionError(f) : lt; f = 'lt'; operator = '<' }


### PR DESCRIPTION
Currently this won't get passed to dynamo

    filters: [{ attr: 'evs', eq: false }]

So, this changes the builder to be "did you pass it to me?"

fixes #41 