### PR TITLE
Allow attributes not specified in entity to be passed through

### DIFF
--- a/__tests__/formatItem.unit.test.js
+++ b/__tests__/formatItem.unit.test.js
@@ -29,12 +29,12 @@ DefaultTable.entities = new Entity({
     test: 'map',
     linked1: ['sk',0, { save: false }],
     linked2: ['sk',1, { save: false }],
-    composite: { type: 'string', alias: 'composite_alias' },
-    linked_alias1: ['composite',0, { save: false, alias: 'linked_alias2' }],
-    linked_alias3: ['composite',1, { save: false, alias: 'linked_alias4' }],
+    composite1: { type: 'string', alias: 'composite1_alias' },
+    linked3: ['composite1',0, { save: false }],
+    linked4: ['composite1',1, { save: false, alias: 'linked4_alias' }],
     composite2_alias: { type: 'string', map: 'composite2' },
-    linked_alias5: ['composite2_alias',0, { save: false }],
-    linked_alias7: ['composite2_alias',1, { save: false }],
+    linked5: ['composite2_alias',0, { save: false, }],
+    linked6: ['composite2_alias',1, { save: false, alias: 'linked6_alias' }],
   }
 })
 
@@ -89,14 +89,14 @@ describe('formatItem', () => {
     expect(result).toEqual({ linked1: 'test1' })
   })
 
-  it('formats item with linked aliased fields', () => {
-    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite: 'test1#test2' })  
-    expect(result).toEqual({ composite_alias: 'test1#test2', linked_alias2: 'test1', linked_alias4: 'test2' })
+  it('formats item with linked aliased composite field', () => {
+    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite1: 'test1#test2' })  
+    expect(result).toEqual({ composite1_alias: 'test1#test2', linked3: 'test1', linked4_alias: 'test2' })
   })
 
-  it('formats item with linked mapped fields', () => {
-    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite2: 'test1#test2' })  
-    expect(result).toEqual({ composite2_alias: 'test1#test2', linked_alias5: 'test1', linked_alias7: 'test2' })
+  it('formats item with linked mapped composite field', () => {
+    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite2: 'test1#test2'  })  
+    expect(result).toEqual({ composite2_alias: 'test1#test2', linked5: 'test1', linked6_alias: 'test2' })
   })
 
   it('passes through attribute not specified in entity', () => {

--- a/__tests__/formatItem.unit.test.js
+++ b/__tests__/formatItem.unit.test.js
@@ -83,4 +83,9 @@ describe('formatItem', () => {
     expect(result).toEqual({ linked1: 'test1' })
   })
 
+  it('passes through attribute not specified in entity', () => {
+    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ unspecified: 'value' })  
+    expect(result).toEqual({ unspecified: 'value' })
+  })
+
 })

--- a/__tests__/formatItem.unit.test.js
+++ b/__tests__/formatItem.unit.test.js
@@ -30,8 +30,11 @@ DefaultTable.entities = new Entity({
     linked1: ['sk',0, { save: false }],
     linked2: ['sk',1, { save: false }],
     composite: { type: 'string', alias: 'composite_alias' },
-    linked_alias1: ['composite',0, { save: false, alias: 'linked_alias_one' }],
-    linked_alias2: ['composite',1, { save: false, alias: 'linked_alias_two' }],
+    linked_alias1: ['composite',0, { save: false, alias: 'linked_alias2' }],
+    linked_alias3: ['composite',1, { save: false, alias: 'linked_alias4' }],
+    composite2_alias: { type: 'string', map: 'composite2' },
+    linked_alias5: ['composite2_alias',0, { save: false }],
+    linked_alias7: ['composite2_alias',1, { save: false }],
   }
 })
 
@@ -88,7 +91,12 @@ describe('formatItem', () => {
 
   it('formats item with linked aliased fields', () => {
     let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite: 'test1#test2' })  
-    expect(result).toEqual({ composite_alias: 'test1#test2', linked_alias_one: 'test1', linked_alias_two: 'test2' })
+    expect(result).toEqual({ composite_alias: 'test1#test2', linked_alias2: 'test1', linked_alias4: 'test2' })
+  })
+
+  it('formats item with linked mapped fields', () => {
+    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite2: 'test1#test2' })  
+    expect(result).toEqual({ composite2_alias: 'test1#test2', linked_alias5: 'test1', linked_alias7: 'test2' })
   })
 
   it('passes through attribute not specified in entity', () => {

--- a/__tests__/formatItem.unit.test.js
+++ b/__tests__/formatItem.unit.test.js
@@ -28,7 +28,10 @@ DefaultTable.entities = new Entity({
     list_alias2: { type: 'list', map: 'list2' },
     test: 'map',
     linked1: ['sk',0, { save: false }],
-    linked2: ['sk',1, { save: false }]
+    linked2: ['sk',1, { save: false }],
+    composite: { type: 'string', alias: 'composite_alias' },
+    linked_alias1: ['composite',0, { save: false, alias: 'linked_alias_one' }],
+    linked_alias2: ['composite',1, { save: false, alias: 'linked_alias_two' }],
   }
 })
 
@@ -81,6 +84,11 @@ describe('formatItem', () => {
   it('specifies attributes to include with linked fields', () => {
     let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ sk: 'test1#test2' }, ['linked1'])
     expect(result).toEqual({ linked1: 'test1' })
+  })
+
+  it('formats item with linked aliased fields', () => {
+    let result = formatItem(DocumentClient)(DefaultTable.User.schema.attributes,DefaultTable.User.linked,{ composite: 'test1#test2' })  
+    expect(result).toEqual({ composite_alias: 'test1#test2', linked_alias_one: 'test1', linked_alias_two: 'test2' })
   })
 
   it('passes through attribute not specified in entity', () => {

--- a/lib/formatItem.js
+++ b/lib/formatItem.js
@@ -19,7 +19,7 @@ module.exports = (DocumentClient) => (attributes,linked,item,include=[]) => {
 
   return Object.keys(item).reduce((acc,field) => {
 
-    if (linked[field] || linked[attributes[field].alias]) {
+    if (linked[field] || attributes[field] && linked[attributes[field]] && linked[attributes[field]].alias) {
       Object.assign(acc, (linked[field] || linked[attributes[field].alias]).reduce((acc,f,i) => {
         if (attributes[f].save || attributes[f].hidden || (include.length > 0 && !include.includes(f))) return acc    
         return Object.assign(acc,{
@@ -38,7 +38,7 @@ module.exports = (DocumentClient) => (attributes,linked,item,include=[]) => {
     if (attributes[field] && attributes[field].type === 'set' && Array.isArray(item[field].values)) { item[field] = item[field].values } 
     return Object.assign(acc,{
       [(attributes[field] && attributes[field].alias) || field]: (
-        attributes[field].prefix || attributes[field].suffix
+        attributes[field] && (attributes[field].prefix || attributes[field].suffix)
           ? item[field]
             .replace(new RegExp(`^${escapeRegExp(attributes[field].prefix)}`),'')
             .replace(new RegExp(`${escapeRegExp(attributes[field].suffix)}$`),'')

--- a/lib/formatItem.js
+++ b/lib/formatItem.js
@@ -18,9 +18,8 @@ module.exports = (DocumentClient) => (attributes,linked,item,include=[]) => {
   const validateType = validateTypes(DocumentClient)
 
   return Object.keys(item).reduce((acc,field) => {
-
-    if (linked[field] || attributes[field] && linked[attributes[field]] && linked[attributes[field]].alias) {
-      Object.assign(acc, (linked[field] || linked[attributes[field].alias]).reduce((acc,f,i) => {
+    if (linked[field]) {
+      Object.assign(acc, (linked[field]).reduce((acc,f,i) => {
         if (attributes[f].save || attributes[f].hidden || (include.length > 0 && !include.includes(f))) return acc    
         return Object.assign(acc,{
           [attributes[f].alias || f]: validateType(attributes[f],f,

--- a/lib/formatItem.js
+++ b/lib/formatItem.js
@@ -18,8 +18,9 @@ module.exports = (DocumentClient) => (attributes,linked,item,include=[]) => {
   const validateType = validateTypes(DocumentClient)
 
   return Object.keys(item).reduce((acc,field) => {
-    if (linked[field]) {
-      Object.assign(acc, (linked[field]).reduce((acc,f,i) => {
+    const link = linked[field] || attributes[field] && attributes[field].alias && linked[attributes[field].alias]
+    if (link) {
+      Object.assign(acc, link.reduce((acc,f,i) => {
         if (attributes[f].save || attributes[f].hidden || (include.length > 0 && !include.includes(f))) return acc    
         return Object.assign(acc,{
           [attributes[f].alias || f]: validateType(attributes[f],f,


### PR DESCRIPTION
Fixes #50 

Looking at the code I figured this was a bug, since there were guards for everything else.

PS. Thanks for this library, truly makes single table design approachable 🥇 