### PR TITLE
only set ExpressionAttributeValues when needed (resolves #51)

### DIFF
--- a/classes/Entity.js
+++ b/classes/Entity.js
@@ -760,8 +760,11 @@ class Entity {
         // TODO: alias attribute field names        
         // Add names, values and condition expression
         ExpressionAttributeNames = names
-        ExpressionAttributeValues = values
         ConditionExpression = expression
+        
+        if (Object.keys(values).length > 0) {
+          ExpressionAttributeValues = values
+        }
       } // end if names
       
     } // end if filters


### PR DESCRIPTION
When only using conditions like {attr: 'id', exists: true}
there aren't any attribute values created but the option is still passed.
The DynamoDB api sees this as a ValidationException.