### PR TITLE
Support hyphens in field names. Fixes #94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dump.rdb
 
 # coverage
 coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ The optional second argument accepts an `options` object. The following options 
 | capacity | `string` | Return the amount of consumed capacity. One of either `none`, `total`, or `indexes` (ReturnConsumedCapacity) |
 | metrics | `string` | Return item collection metrics. If set to `size`, the response includes statistics about item collections, if any, that were modified during the operation are returned in the response. One of either `none` or `size` (ReturnItemCollectionMetrics) |
 | returnValues | `string` | Determines whether to return item attributes as they appeared before they were deleted. One of either `none` or `all_old`. (ReturnValues) |
-| makeFieldName | `(fieldName: string, index: number) => string` | Convert the field name for use in update expressions. This is necessary if you use [hyphens/dashes](https://github.com/jeremydaly/dynamodb-toolbox/issues/94) in your field names. Examples: `(fieldName, index) => `f_${index}` or `(fieldName, index) => f.gsub(/-/g, '_')`. |
+| makeFieldName | `(fieldName: string, index: number) => string` | Convert the field name for use in update expressions. This is necessary if you use [hyphens/dashes](https://github.com/jeremydaly/dynamodb-toolbox/issues/94) in your field names. Examples: `(fieldName, index) => `f_${index}` or `(fieldName, index) => f.replace(/-/g, '_')`. |
 | execute | `boolean` | Enables/disables automatic execution of the DocumentClient method (default: *inherited from Entity*) |
 | parse | `boolean` | Enables/disables automatic parsing of returned data when `autoExecute` evaluates to `true` (default: *inherited from Entity*) |
 

--- a/README.md
+++ b/README.md
@@ -799,7 +799,8 @@ The optional second argument accepts an `options` object. The following options 
 | conditions | `array` or `object` | A complex `object` or `array` of objects that specifies the conditions that must be met to delete the item. See [Filters and Conditions](#filters-and-conditions). (ConditionExpression) |
 | capacity | `string` | Return the amount of consumed capacity. One of either `none`, `total`, or `indexes` (ReturnConsumedCapacity) |
 | metrics | `string` | Return item collection metrics. If set to `size`, the response includes statistics about item collections, if any, that were modified during the operation are returned in the response. One of either `none` or `size` (ReturnItemCollectionMetrics) |
-| returnValues | `string` | Determins whether to return item attributes as they appeared before they were deleted. One of either `none` or `all_old`. (ReturnValues) |
+| returnValues | `string` | Determines whether to return item attributes as they appeared before they were deleted. One of either `none` or `all_old`. (ReturnValues) |
+| makeFieldName | `(fieldName: string, index: number) => string` | Convert the field name for use in update expressions. This is necessary if you use [hyphens]() in your field names. Examples: `(fieldName, index) => `f_${index}` or `(fieldName, index) => f.gsub(/-/g, '_')`. |
 | execute | `boolean` | Enables/disables automatic execution of the DocumentClient method (default: *inherited from Entity*) |
 | parse | `boolean` | Enables/disables automatic parsing of returned data when `autoExecute` evaluates to `true` (default: *inherited from Entity*) |
 

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ The optional second argument accepts an `options` object. The following options 
 | capacity | `string` | Return the amount of consumed capacity. One of either `none`, `total`, or `indexes` (ReturnConsumedCapacity) |
 | metrics | `string` | Return item collection metrics. If set to `size`, the response includes statistics about item collections, if any, that were modified during the operation are returned in the response. One of either `none` or `size` (ReturnItemCollectionMetrics) |
 | returnValues | `string` | Determines whether to return item attributes as they appeared before they were deleted. One of either `none` or `all_old`. (ReturnValues) |
-| makeFieldName | `(fieldName: string, index: number) => string` | Convert the field name for use in update expressions. This is necessary if you use [hyphens]() in your field names. Examples: `(fieldName, index) => `f_${index}` or `(fieldName, index) => f.gsub(/-/g, '_')`. |
+| makeFieldName | `(fieldName: string, index: number) => string` | Convert the field name for use in update expressions. This is necessary if you use [hyphens/dashes](https://github.com/jeremydaly/dynamodb-toolbox/issues/94) in your field names. Examples: `(fieldName, index) => `f_${index}` or `(fieldName, index) => f.gsub(/-/g, '_')`. |
 | execute | `boolean` | Enables/disables automatic execution of the DocumentClient method (default: *inherited from Entity*) |
 | parse | `boolean` | Enables/disables automatic parsing of returned data when `autoExecute` evaluates to `true` (default: *inherited from Entity*) |
 

--- a/__tests__/entity.update.unit.test.js
+++ b/__tests__/entity.update.unit.test.js
@@ -268,6 +268,37 @@ describe('update',()=>{
     expect(ExpressionAttributeValues[':test_boolean_coerce']).toBe(false)
   })
 
+  it('maps field names', () => {
+    let { TableName, Key, UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues } = TestEntity.updateParams({
+      pk: 'test-pk',
+      sk: 'test-sk',
+      test_boolean_coerce: 'false',
+      _ct: '2020-12-08T21:36:47.000Z',
+      _md: '2020-12-08T21:36:47.050Z'
+
+    }, {
+      makeFieldName: (field, index) => `f_${index}`
+    })
+    expect(UpdateExpression).toEqual('SET #f_0 = if_not_exists(#f_0,:f_0), #f_1 = if_not_exists(#f_1,:f_1), #f_2 = if_not_exists(#f_2,:f_2), #f_3 = :f_3, #f_4 = :f_4, #f_5 = if_not_exists(#f_5,:f_5), #f_8 = :f_8')
+    expect(ExpressionAttributeValues).toEqual({
+      ':f_0': 'default string',
+      ':f_1': 0,
+      ':f_2': false,
+      ':f_3': '2020-12-08T21:36:47.000Z',
+      ':f_4': '2020-12-08T21:36:47.050Z',
+      ':f_5': 'TestEntity',
+      ':f_8': false
+    })
+    expect(ExpressionAttributeNames).toEqual({
+      '#f_0': 'test_string',
+      '#f_1': 'test_number_coerce',
+      '#f_2': 'test_boolean_default',
+      '#f_3': '_ct',
+      '#f_4': '_md',
+      '#f_5': '_et',
+      '#f_8': 'test_boolean_coerce'
+    })
+  })
 
   it('creates a set', () => {
     let { TableName, Key, UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues } = TestEntity.updateParams({


### PR DESCRIPTION
First off - thanks for this wonderful library. It's saved us a ton of time and simplified our code significantly. Well done!

This is a fix for #94.

I opted for a solution that allows users to pass an optional `makeFieldName` option to `Entity#update`, for example:

```javascript
makeFieldName: (field, index) => `f_${index}`
```

This works too:

```javascript
makeFieldName: (field) => field.replace(/-/g, '_')
```

It might be better to bake this into the library and *always* do the transformation (without passing `makeFieldName`), but I thought this implementation might be better as a first step.