### PR TITLE
fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can then get the data:
 let item = {
   id: 123,
   status: 'active',
-  date_added: '2019-04-24'
+  date_added: '2020-04-24'
 }
 
 // Use the 'get' method of Customer


### PR DESCRIPTION
I used this readme a few times to copy and paste the example, and every time I was surprised that it seemingly didn't work :)
BTW I edited the readme using github interface, not sure why it changed the file ending, but maybe that's actually a correct change if github is forcing it?