### PR TITLE
added null to SchemaType; exported SchemaType

### DIFF
--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -21,10 +21,11 @@ import parseProjections, { ProjectionAttributes } from '../lib/projectionBuilder
 import { error, transformAttr, isEmpty } from '../lib/utils'
 import { Document } from 'aws-sdk/clients/textract'
 
-type SchemaType =
+export type SchemaType =
   | string
   | number
   | boolean
+  | null
   | { [key: string]: SchemaType }
   | SchemaType[]
 


### PR DESCRIPTION
In regards to https://github.com/jeremydaly/dynamodb-toolbox/issues/127

Excerpt from that issue:

> When I try:
```
Entity.putTransaction({ something: null })
```

I get the following TypeScript error:
> TS2322: Type 'null' is not assignable to type 'string | number | boolean | { [key: string]: SchemaType; } | SchemaType[] | undefined'.

Shouldn't `null` be a valid attribute value to pass to an entity, so long as it is not the PK or SK?


Proposed change to `Entity.ts` (also exporting `SchemaType` to be used directly in projects:
```
export type SchemaType =
  | string
  | number
  | boolean
  | { [key: string]: SchemaType }
  | SchemaType[]
  | null
```