### PR TITLE
Fix type of transform entity config

### DIFF
--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -47,7 +47,7 @@ export interface EntityAttributeConfig {
   type?: DynamoDBTypes
   default?: any | ((data: object) => any)
   dependsOn?: string | string[]
-  transform?: (value: any, data: {}) => { resp: any }
+  transform?: (value: any, data: {}) => any
   coerce?: boolean
   save?: boolean
   onUpdate?: boolean


### PR DESCRIPTION
I'm pretty sure this type is wrong, looking at how `transform` is used by [`utils/transformAttr`](https://github.com/jeremydaly/dynamodb-toolbox/blob/09ddf4f144c3119802f44119060138ca5183b46e/src/lib/utils.ts#L45).

Encountered this when upgrading a TS codebase to `v0.3` from `v0.2` which uses transforms a fair amount. All my tests passed with this change, and the code wouldn't compile without it.