### PR TITLE
Fix required check not accepting 0 and false

### DIFF
--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -88,6 +88,17 @@ const TestEntity4 = new Entity({
   table: TestTable3
 });
 
+const TestEntity5 = new Entity({
+  name: 'TestEntity5',
+  autoExecute: false,
+  attributes: {
+    pk: { partitionKey: true },
+    test_required_boolean: { type: 'boolean', required: true },
+    test_required_number: { type: 'number', required: true },
+  },
+  table: TestTable2
+})
+
 describe('put',()=>{
 
   it('creates basic item',() => {
@@ -289,6 +300,17 @@ describe('put',()=>{
       'pk': 'test-pk',
       'test2': 'test'
     })).toThrow(`'test' is a required field`)
+  })
+
+  it('puts 0 and false to required fields', () => {
+    let { Item } = TestEntity5.putParams({
+      pk: 'test-pk',
+      test_required_boolean: false,
+      test_required_number: 0
+    })
+
+    expect(Item.test_required_boolean).toBe(false)
+    expect(Item.test_required_number).toBe(0)
   })
 
   it('formats a batch put response', async () => {

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -1109,8 +1109,7 @@ class Entity<
 
 
     // Check for required fields
-    Object.keys(required).forEach(field => 
-      required[field] !== undefined && data[field] !== null
+    Object.keys(required).forEach(field => required[field] !== undefined && (data[field] === undefined || data[field] === null)
         && error(`'${field}${this.schema.attributes[field].alias ? `/${this.schema.attributes[field].alias}` : ''}' is a required field`)
     ) // end required field check
 

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -1110,7 +1110,7 @@ class Entity<
 
     // Check for required fields
     Object.keys(required).forEach(field => 
-      required[field] !== undefined && !data[field] 
+      required[field] !== undefined && data[field] !== null
         && error(`'${field}${this.schema.attributes[field].alias ? `/${this.schema.attributes[field].alias}` : ''}' is a required field`)
     ) // end required field check
 


### PR DESCRIPTION
Fix for https://github.com/jeremydaly/dynamodb-toolbox/issues/154

`required: true` is not accepting `false` and `0` values being passed into an Entity put.