### PR TITLE
Support `timestamp` option in inferred types

### DIFF
--- a/src/__tests__/entity.delete.unit.test.ts
+++ b/src/__tests__/entity.delete.unit.test.ts
@@ -45,7 +45,6 @@ describe('delete', () => {
   })
 
   it('deletes the key from inputs (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type
     const { TableName, Key } = await TestEntity.delete({ email: 'test-pk', sort: 'test-sk' })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
@@ -63,7 +62,6 @@ describe('delete', () => {
   })
 
   it('filters out extra data (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type
     let { TableName, Key } = await TestEntity.delete({
       email: 'test-pk',
       sort: 'test-sk',
@@ -82,7 +80,7 @@ describe('delete', () => {
   })
 
   it('coerces key values to correct types (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type + Support coerce keyword
+    // @ts-expect-error 💥 TODO: Support coerce keyword
     let { TableName, Key } = await TestEntity.delete({ email: 1, sort: true })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: '1', sk: 'true' })

--- a/src/__tests__/entity.get.unit.test.ts
+++ b/src/__tests__/entity.get.unit.test.ts
@@ -45,7 +45,6 @@ describe('get', () => {
   })
 
   it('gets the key from inputs (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ?
     const { TableName, Key } = await TestEntity.get({ email: 'test-pk', sort: 'test-sk' })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
@@ -63,7 +62,6 @@ describe('get', () => {
   })
 
   it('filters out extra data (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ?
     let { TableName, Key } = await TestEntity.get({
       email: 'test-pk',
       sort: 'test-sk',
@@ -82,7 +80,7 @@ describe('get', () => {
   })
 
   it('coerces key values to correct types (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ? + Support coerce keyword
+    // @ts-expect-error 💥 TODO: Support coerce keyword
     let { TableName, Key } = await TestEntity.get({ email: 1, sort: true })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: '1', sk: 'true' })

--- a/src/__tests__/entity.utils.unit.test.ts
+++ b/src/__tests__/entity.utils.unit.test.ts
@@ -1,0 +1,24 @@
+import { shouldExecute, shouldParse } from '../classes/Entity'
+
+describe('Entity - utils', () => {
+  it('should execute', () => {
+    expect(shouldExecute(true, true)).toBe(true)
+    expect(shouldExecute(true, false)).toBe(true)
+    expect(shouldExecute(undefined, true)).toBe(true)
+  })
+  it('should not execute', () => {
+    expect(shouldExecute(false, false)).toBe(false)
+    expect(shouldExecute(undefined, false)).toBe(false)
+    expect(shouldExecute(false, true)).toBe(false)
+  })
+  it('should parse', () => {
+    expect(shouldParse(true, true)).toBe(true)
+    expect(shouldParse(true, false)).toBe(true)
+    expect(shouldParse(undefined, true)).toBe(true)
+  })
+  it('should not parse', () => {
+    expect(shouldParse(false, false)).toBe(false)
+    expect(shouldParse(undefined, false)).toBe(false)
+    expect(shouldParse(false, true)).toBe(false)
+  })
+})

--- a/src/__tests__/parseMapping.unit.test.ts
+++ b/src/__tests__/parseMapping.unit.test.ts
@@ -128,7 +128,6 @@ describe('parseMapping', () => {
   })
 
   it('parses partitionKey as string', async () => {
-    // @ts-expect-error 💥 TODO: Support GSIs
     expect(parseMapping('attr', { type: 'string', partitionKey: 'GSI' }, track)).toEqual({
       attr: { type: 'string', partitionKey: 'GSI', coerce: true }
     })
@@ -178,7 +177,6 @@ describe('parseMapping', () => {
     expect(() => {
       parseMapping(
         'attr',
-        // @ts-expect-error 💥 TODO: Support GSIs
         { type: 'string', partitionKey: 'GSI' },
         Object.assign({}, track, { keys: { GSI: { partitionKey: 'GSIpk' } } })
       )
@@ -200,7 +198,6 @@ describe('parseMapping', () => {
     expect(() => {
       parseMapping(
         'attr',
-        // @ts-expect-error 💥 TODO: Support GSIs
         { type: 'string', sortKey: 'GSI' },
         Object.assign({}, track, { keys: { GSI: { partitionKey: 'attr' } } })
       )

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -183,6 +183,17 @@ describe('Entity', () => {
       table: tableWithoutSK
     } as const)
 
+    const entNoTimestamps = new Entity({
+      name: entityName,
+      timestamps: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
     type ExpectedItem = {
       created: string
       modified: string
@@ -254,6 +265,18 @@ describe('Entity', () => {
         type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
         const testGetRawResponse: TestGetRawResponse = 1
         testGetRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const getPromise = () => entNoTimestamps.get(item)
+        type GetResponse = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetResponse = A.Equals<
+          GetResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testGetResponse: TestGetResponse = 1
+        testGetResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -355,6 +378,18 @@ describe('Entity', () => {
         testDeleteRawResponse
       })
 
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const deletePromise = () => entNoTimestamps.delete(item, { returnValues: 'ALL_OLD' })
+        type DeleteResponse = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteResponse = A.Equals<
+          DeleteResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testDeleteResponse: TestDeleteResponse = 1
+        testDeleteResponse
+      })
+
       it('throws when primary key is incomplete', () => {
         // @ts-expect-error
         expect(() => ent.deleteParams({})).toThrow()
@@ -451,6 +486,18 @@ describe('Entity', () => {
         type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
         const testPutRawResponse: TestPutRawResponse = 1
         testPutRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const putPromise = () => entNoTimestamps.put(item, { returnValues: 'ALL_OLD' })
+        type PutResponse = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutResponse = A.Equals<
+          PutResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testPutResponse: TestPutResponse = 1
+        testPutResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -554,6 +601,18 @@ describe('Entity', () => {
         >
         const testUpdateRawResponse: TestUpdateRawResponse = 1
         testUpdateRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const updatePromise = () => entNoTimestamps.update(item, { returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<
+          UpdateItem,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
       })
 
       it('throws when primary key is incomplete', () => {

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -1,4 +1,5 @@
 import { DynamoDB } from 'aws-sdk'
+import { DocumentClient as DocumentClientType } from 'aws-sdk/clients/dynamodb'
 import MockDate from 'mockdate'
 import { A, C, F, O } from 'ts-toolbelt'
 
@@ -160,6 +161,28 @@ describe('Entity', () => {
       table: tableWithoutSK
     } as const)
 
+    const entNoExecute = new Entity({
+      name: entityName,
+      autoExecute: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
+    const entNoParse = new Entity({
+      name: entityName,
+      autoParse: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
     type ExpectedItem = {
       created: string
       modified: string
@@ -177,6 +200,60 @@ describe('Entity', () => {
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const getPromise = () => entNoExecute.get(item)
+        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
+        const testGetParams: TestGetParams = 1
+        testGetParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const getPromise = () => entNoExecute.get(item, { execute: true })
+        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
+        const testGetItem: TestGetItem = 1
+        testGetItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const getPromise = () => ent.get(item, { execute: false })
+        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
+        const testGetParams: TestGetParams = 1
+        testGetParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const getPromise = () => entNoParse.get(item)
+        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
+        const testGetRawResponse: TestGetRawResponse = 1
+        testGetRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const getPromise = () => entNoParse.get(item, { parse: true })
+        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
+        const testGetItem: TestGetItem = 1
+        testGetItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const getPromise = () => ent.get(item, { parse: false })
+        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
+        const testGetRawResponse: TestGetRawResponse = 1
+        testGetRawResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -214,6 +291,68 @@ describe('Entity', () => {
         type TestDeleteItem2 = A.Equals<DeleteItem2, ExpectedItem | undefined>
         const testDeleteItem2: TestDeleteItem2 = 1
         testDeleteItem2
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const deletePromise = () => entNoExecute.delete(item)
+        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
+        const testDeleteParams: TestDeleteParams = 1
+        testDeleteParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const deletePromise = () =>
+          entNoExecute.delete(item, { execute: true, returnValues: 'ALL_OLD' })
+        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
+        const testDeleteItem: TestDeleteItem = 1
+        testDeleteItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const deletePromise = () => ent.delete(item, { execute: false })
+        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
+        const testDeleteParams: TestDeleteParams = 1
+        testDeleteParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const deletePromise = () => entNoParse.delete(item)
+        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteRawResponse = A.Equals<
+          DeleteRawResponse,
+          DocumentClientType.DeleteItemOutput
+        >
+        const testDeleteRawResponse: TestDeleteRawResponse = 1
+        testDeleteRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const deletePromise = () =>
+          entNoParse.delete(item, { parse: true, returnValues: 'ALL_OLD' })
+        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
+        const testDeleteItem: TestDeleteItem = 1
+        testDeleteItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const deletePromise = () => ent.update(item, { parse: false })
+        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteRawResponse = A.Equals<
+          DeleteRawResponse,
+          DocumentClientType.DeleteItemOutput
+        >
+        const testDeleteRawResponse: TestDeleteRawResponse = 1
+        testDeleteRawResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -260,6 +399,60 @@ describe('Entity', () => {
         testPutItem2
       })
 
+      it('no auto-execution', () => {
+        const item = { pk }
+        const putPromise = () => entNoExecute.put(item)
+        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
+        const testPutParams: TestPutParams = 1
+        testPutParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const putPromise = () => entNoExecute.put(item, { execute: true, returnValues: 'ALL_OLD' })
+        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
+        const testPutItem: TestPutItem = 1
+        testPutItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const putPromise = () => ent.put(item, { execute: false, returnValues: 'ALL_OLD' })
+        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
+        const testPutParams: TestPutParams = 1
+        testPutParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const putPromise = () => entNoParse.put(item)
+        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
+        const testPutRawResponse: TestPutRawResponse = 1
+        testPutRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const putPromise = () => entNoParse.put(item, { parse: true, returnValues: 'ALL_OLD' })
+        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
+        const testPutItem: TestPutItem = 1
+        testPutItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const putPromise = () => ent.put(item, { parse: false })
+        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
+        const testPutRawResponse: TestPutRawResponse = 1
+        testPutRawResponse
+      })
+
       it('throws when primary key is incomplete', () => {
         // @ts-expect-error
         expect(() => ent.putParams({})).toThrow()
@@ -299,6 +492,68 @@ describe('Entity', () => {
         type TestUpdateItem2 = A.Equals<UpdateItem2, ExpectedItem | undefined>
         const testUpdateItem2: TestUpdateItem2 = 1
         testUpdateItem2
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const updatePromise = () => entNoExecute.update(item)
+        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
+        const testUpdateParams: TestUpdateParams = 1
+        testUpdateParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const updatePromise = () =>
+          entNoExecute.update(item, { execute: true, returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const updatePromise = () => ent.update(item, { execute: false })
+        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
+        const testUpdateParams: TestUpdateParams = 1
+        testUpdateParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const updatePromise = () => entNoParse.update(item)
+        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateRawResponse = A.Equals<
+          UpdateRawResponse,
+          DocumentClientType.UpdateItemOutput
+        >
+        const testUpdateRawResponse: TestUpdateRawResponse = 1
+        testUpdateRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const updatePromise = () =>
+          entNoParse.update(item, { parse: true, returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const updatePromise = () => ent.update(item, { parse: false })
+        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateRawResponse = A.Equals<
+          UpdateRawResponse,
+          DocumentClientType.UpdateItemOutput
+        >
+        const testUpdateRawResponse: TestUpdateRawResponse = 1
+        testUpdateRawResponse
       })
 
       it('throws when primary key is incomplete', () => {

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -38,6 +38,8 @@ export function parseEntity<
   CreatedAlias extends string,
   ModifiedAlias extends string,
   TypeAlias extends string,
+  AutoExecute extends boolean,
+  AutoParse extends boolean,
   ReadonlyAttributeDefinitions extends PreventKeys<
     AttributeDefinitions | O.Readonly<AttributeDefinitions, A.Key, 'deep'>,
     CreatedAlias | ModifiedAlias | TypeAlias
@@ -49,6 +51,8 @@ export function parseEntity<
     CreatedAlias,
     ModifiedAlias,
     TypeAlias,
+    AutoExecute,
+    AutoParse,
     ReadonlyAttributeDefinitions
   >
 ) {

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -35,11 +35,12 @@ export type ParsedEntity = ReturnType<typeof parseEntity>
 export function parseEntity<
   EntityTable extends TableType | undefined,
   Name extends string,
+  AutoExecute extends boolean,
+  AutoParse extends boolean,
+  Timestamps extends boolean,
   CreatedAlias extends string,
   ModifiedAlias extends string,
   TypeAlias extends string,
-  AutoExecute extends boolean,
-  AutoParse extends boolean,
   ReadonlyAttributeDefinitions extends PreventKeys<
     AttributeDefinitions | O.Readonly<AttributeDefinitions, A.Key, 'deep'>,
     CreatedAlias | ModifiedAlias | TypeAlias
@@ -48,11 +49,12 @@ export function parseEntity<
   entity: EntityConstructor<
     EntityTable,
     Name,
+    AutoExecute,
+    AutoParse,
+    Timestamps,
     CreatedAlias,
     ModifiedAlias,
     TypeAlias,
-    AutoExecute,
-    AutoParse,
     ReadonlyAttributeDefinitions
   >
 ) {
@@ -79,36 +81,43 @@ export function parseEntity<
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Entity name
-  name = (typeof name === 'string' && name.trim().length > 0
-    ? name.trim()
-    : error(`'name' must be defined`)) as Name
+  name = (
+    typeof name === 'string' && name.trim().length > 0
+      ? name.trim()
+      : error(`'name' must be defined`)
+  ) as Name
 
+  // 🔨 TOIMPROVE: Use default option & simply throw if type is incorrect
   // Enable created/modified timestamps on items
-  timestamps = typeof timestamps === 'boolean' ? timestamps : true
+  timestamps = (typeof timestamps === 'boolean' ? timestamps : true) as Timestamps
 
   // Define 'created' attribute name
   created = typeof created === 'string' && created.trim().length > 0 ? created.trim() : '_ct'
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'createdAlias'
-  createdAlias = (typeof createdAlias === 'string' && createdAlias.trim().length > 0
-    ? createdAlias.trim()
-    : 'created') as CreatedAlias
+  createdAlias = (
+    typeof createdAlias === 'string' && createdAlias.trim().length > 0
+      ? createdAlias.trim()
+      : 'created'
+  ) as CreatedAlias
 
   // Define 'modified' attribute anme
   modified = typeof modified === 'string' && modified.trim().length > 0 ? modified.trim() : '_md'
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'modifiedAlias'
-  modifiedAlias = (typeof modifiedAlias === 'string' && modifiedAlias.trim().length > 0
-    ? modifiedAlias.trim()
-    : 'modified') as ModifiedAlias
+  modifiedAlias = (
+    typeof modifiedAlias === 'string' && modifiedAlias.trim().length > 0
+      ? modifiedAlias.trim()
+      : 'modified'
+  ) as ModifiedAlias
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'entityAlias'
-  typeAlias = (typeof typeAlias === 'string' && typeAlias.trim().length > 0
-    ? typeAlias.trim()
-    : 'entity') as TypeAlias
+  typeAlias = (
+    typeof typeAlias === 'string' && typeAlias.trim().length > 0 ? typeAlias.trim() : 'entity'
+  ) as TypeAlias
 
   // Sanity check the attributes
   attributes =

--- a/src/lib/parseMapping.ts
+++ b/src/lib/parseMapping.ts
@@ -6,7 +6,9 @@
 
 import {
   PartitionKeyDefinition,
+  GSIPartitionKeyDefinition,
   SortKeyDefinition,
+  GSISortKeyDefinition,
   PureAttributeDefinition
 } from '../classes/Entity'
 import { TrackingInfo } from './parseEntity'
@@ -15,7 +17,12 @@ import { error } from './utils'
 // Parse and validate mapping config
 export default (
   field: string,
-  config: PartitionKeyDefinition | SortKeyDefinition | PureAttributeDefinition,
+  config:
+    | PartitionKeyDefinition
+    | GSIPartitionKeyDefinition
+    | SortKeyDefinition
+    | GSISortKeyDefinition
+    | PureAttributeDefinition,
   track: TrackingInfo
 ) => {
   // Validate props


### PR DESCRIPTION
This PR adds support for `timestamp` option in inferred types:

```typescript
const regularEntity = new Entity({
  name: entityName,
  attributes: {
    pk: { type: 'string', partitionKey: true },
  },
  table: tableWithoutSK
} as const)

const { Item } = await regularEntity.get({ pk: 'pk' })
type RegularItem = typeof Item
// => { entity: string, created: string, modified: string, pk: string }

const entNoTimestamps = new Entity({
  name: entityName,
  timestamps: false,
  attributes: {
    pk: { type: 'string', partitionKey: true },
  },
  table: tableWithoutSK
} as const)


const { Item } = await entNoTimestamps.get({ pk: 'pk' })
type NoTimestampItem = typeof Item
// => { entity: string, pk: string } 🙌
```