### PR TITLE
Create a sort key of a global index when it is a part of a primary key

### DIFF
--- a/src/__tests__/normalizeData.unit.test.ts
+++ b/src/__tests__/normalizeData.unit.test.ts
@@ -19,7 +19,7 @@ let DefaultTable = new Table({
 DefaultTable.entities = new Entity({
   name: 'User',
   attributes: {
-    pk: { type: 'string', partitionKey: true },
+    id: { type: 'string', partitionKey: true },
     sk: { type: 'string', sortKey: true },
     set: { type: 'set', setType: 'string', alias: 'set_alias' },
     set_alias2: { type: 'set', setType: 'string', map: 'set2' },
@@ -41,7 +41,7 @@ describe('normalizeData', () => {
 
   it('converts entity input to table attributes', async () => {
     let result = normalizeData(DocumentClient)(attributes,linked,{
-      pk: 'test',
+      id: 'test',
       set_alias: ['1','2','3'],
       number: 1,
       test: { test: true },
@@ -64,7 +64,7 @@ describe('normalizeData', () => {
 
   it('filter out non-mapped fields', async () => {
     let result = normalizeData(DocumentClient)(attributes,linked,{
-      pk: 'test',
+      id: 'test',
       $remove: 'testx',
       notAField: 'test123'
     },true)
@@ -77,7 +77,7 @@ describe('normalizeData', () => {
   it('fails on non-mapped fields', async () => {
     expect(() => {
       normalizeData(DocumentClient)(attributes,linked,{
-        pk: 'test',
+        id: 'test',
         $remove: 'testx',
         notAField: 'test123'
       })

--- a/src/lib/normalizeData.ts
+++ b/src/lib/normalizeData.ts
@@ -87,7 +87,7 @@ export default (DocumentClient: DocumentClient) => (schema:any,linked:any,data:a
     const field = (schema[attr] && schema[attr].map) || attr
 
     if (_data[field] !== undefined) return acc // if value exists, let override
-    let values = linked[attr].map((f:any) => {
+    let values = linked[attr].map((unmappedF: any) =>  schema[unmappedF].map ?? unmappedF).map((f:any) => {
       if (_data[f] === undefined) { return null }
       return transformAttr(schema[f],validateType(schema[f],f,_data[f]),_data)
     }).filter((x:any) => x !== null)    


### PR DESCRIPTION
In the following circumstances an attribute corresponding to a sort key of a global index is not created:
- The sort key of a global index is a composite key;
- this composite key is mapped to the primary key;
- the name of the attribute associated with the primary key is not equal to the name of the primary key (in the table definition).

This situation is modeled in the new test “converts entity input to table attributes when primary key is also a part of a sort key of a global index”. Without the suggested patch `normalizeData` doesn’t return `gs1sk` attribute.  To fix this not only the composite fields should be mapped to final field names, but also the fields that are referenced by these composite fields.