### PR TITLE
Export `GetOptions`, `PutOptions`, `DeleteOptions`, `UpdateOptions` & `QueryOptions` utility types

### DIFF
--- a/src/__tests__/entity.delete.unit.test.ts
+++ b/src/__tests__/entity.delete.unit.test.ts
@@ -45,7 +45,6 @@ describe('delete', () => {
   })
 
   it('deletes the key from inputs (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type
     const { TableName, Key } = await TestEntity.delete({ email: 'test-pk', sort: 'test-sk' })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
@@ -63,7 +62,6 @@ describe('delete', () => {
   })
 
   it('filters out extra data (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type
     let { TableName, Key } = await TestEntity.delete({
       email: 'test-pk',
       sort: 'test-sk',
@@ -82,7 +80,7 @@ describe('delete', () => {
   })
 
   it('coerces key values to correct types (async)', async () => {
-    // @ts-expect-error 💥 TODO: Fix return type + Support coerce keyword
+    // @ts-expect-error 💥 TODO: Support coerce keyword
     let { TableName, Key } = await TestEntity.delete({ email: 1, sort: true })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: '1', sk: 'true' })

--- a/src/__tests__/entity.get.unit.test.ts
+++ b/src/__tests__/entity.get.unit.test.ts
@@ -45,7 +45,6 @@ describe('get', () => {
   })
 
   it('gets the key from inputs (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ?
     const { TableName, Key } = await TestEntity.get({ email: 'test-pk', sort: 'test-sk' })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: 'test-pk', sk: 'test-sk' })
@@ -63,7 +62,6 @@ describe('get', () => {
   })
 
   it('filters out extra data (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ?
     let { TableName, Key } = await TestEntity.get({
       email: 'test-pk',
       sort: 'test-sk',
@@ -82,7 +80,7 @@ describe('get', () => {
   })
 
   it('coerces key values to correct types (async)', async () => {
-    // @ts-expect-error 💥 TODO: Correct interface ? + Support coerce keyword
+    // @ts-expect-error 💥 TODO: Support coerce keyword
     let { TableName, Key } = await TestEntity.get({ email: 1, sort: true })
     expect(TableName).toBe('test-table')
     expect(Key).toEqual({ pk: '1', sk: 'true' })

--- a/src/__tests__/entity.utils.unit.test.ts
+++ b/src/__tests__/entity.utils.unit.test.ts
@@ -1,0 +1,24 @@
+import { shouldExecute, shouldParse } from '../classes/Entity'
+
+describe('Entity - utils', () => {
+  it('should execute', () => {
+    expect(shouldExecute(true, true)).toBe(true)
+    expect(shouldExecute(true, false)).toBe(true)
+    expect(shouldExecute(undefined, true)).toBe(true)
+  })
+  it('should not execute', () => {
+    expect(shouldExecute(false, false)).toBe(false)
+    expect(shouldExecute(undefined, false)).toBe(false)
+    expect(shouldExecute(false, true)).toBe(false)
+  })
+  it('should parse', () => {
+    expect(shouldParse(true, true)).toBe(true)
+    expect(shouldParse(true, false)).toBe(true)
+    expect(shouldParse(undefined, true)).toBe(true)
+  })
+  it('should not parse', () => {
+    expect(shouldParse(false, false)).toBe(false)
+    expect(shouldParse(undefined, false)).toBe(false)
+    expect(shouldParse(false, true)).toBe(false)
+  })
+})

--- a/src/__tests__/parseMapping.unit.test.ts
+++ b/src/__tests__/parseMapping.unit.test.ts
@@ -128,7 +128,6 @@ describe('parseMapping', () => {
   })
 
   it('parses partitionKey as string', async () => {
-    // @ts-expect-error 💥 TODO: Support GSIs
     expect(parseMapping('attr', { type: 'string', partitionKey: 'GSI' }, track)).toEqual({
       attr: { type: 'string', partitionKey: 'GSI', coerce: true }
     })
@@ -178,7 +177,6 @@ describe('parseMapping', () => {
     expect(() => {
       parseMapping(
         'attr',
-        // @ts-expect-error 💥 TODO: Support GSIs
         { type: 'string', partitionKey: 'GSI' },
         Object.assign({}, track, { keys: { GSI: { partitionKey: 'GSIpk' } } })
       )
@@ -200,7 +198,6 @@ describe('parseMapping', () => {
     expect(() => {
       parseMapping(
         'attr',
-        // @ts-expect-error 💥 TODO: Support GSIs
         { type: 'string', sortKey: 'GSI' },
         Object.assign({}, track, { keys: { GSI: { partitionKey: 'attr' } } })
       )

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -3,6 +3,15 @@ import { DocumentClient as DocumentClientType } from 'aws-sdk/clients/dynamodb'
 import MockDate from 'mockdate'
 import { A, C, F, O } from 'ts-toolbelt'
 
+import {
+  GetOptions,
+  QueryOptions,
+  PutOptions,
+  DeleteOptions,
+  UpdateOptions,
+  ConditionsOrFilters
+} from 'classes/Entity'
+
 import { Table, Entity } from '../index'
 
 const omit = <O extends Record<string, unknown>, K extends (keyof O)[]>(
@@ -17,6 +26,48 @@ const omit = <O extends Record<string, unknown>, K extends (keyof O)[]>(
 }
 
 const DocumentClient = new DynamoDB.DocumentClient()
+
+type ExpectedReadOpts<Attributes extends A.Key = A.Key> = Partial<{
+  capacity: string
+  execute: boolean
+  parse: boolean
+  attributes: Attributes[]
+  consistent: boolean
+}>
+
+type ExpectedGetOpts<Attributes extends A.Key = A.Key> = Partial<
+  ExpectedReadOpts<Attributes> & { include: string[] }
+>
+
+type ExpectedQueryOpts<Attributes extends A.Key = A.Key> = Partial<
+  ExpectedReadOpts<Attributes> & {
+    index: string
+    limit: number
+    reverse: boolean
+    entity: string
+    select: DocumentClientType.Select
+    filters: ConditionsOrFilters<Attributes>
+    eq: string | number
+    lt: string | number
+    lte: string | number
+    gt: string | number
+    gte: string | number
+    between: [string, string] | [number, number]
+    beginsWith: string
+    startKey: {}
+  }
+>
+
+type ExpectedWriteOpts<Attributes extends A.Key = A.Key, ReturnValues extends string = string> =
+  Partial<{
+    capacity: string
+    execute: boolean
+    parse: boolean
+    conditions: ConditionsOrFilters<Attributes>
+    metrics: string
+    include: string[]
+    returnValues: ReturnValues
+  }>
 
 describe('Entity', () => {
   const mockedDate = '2020-11-22T23:00:00.000Z'
@@ -211,6 +262,11 @@ describe('Entity', () => {
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
+
+        type GetItemOptions = GetOptions<typeof ent>
+        type TestGetItemOptions = A.Equals<GetItemOptions, ExpectedGetOpts<keyof ExpectedItem>>
+        const testGetItemOptions: TestGetItemOptions = 1
+        testGetItemOptions
       })
 
       it('no auto-execution', () => {
@@ -314,6 +370,14 @@ describe('Entity', () => {
         type TestDeleteItem2 = A.Equals<DeleteItem2, ExpectedItem | undefined>
         const testDeleteItem2: TestDeleteItem2 = 1
         testDeleteItem2
+
+        type DeleteItemOptions = DeleteOptions<typeof ent>
+        type TestDeleteItemOptions = A.Equals<
+          DeleteItemOptions,
+          ExpectedWriteOpts<keyof ExpectedItem, 'NONE' | 'ALL_OLD'>
+        >
+        const testDeleteItemOptions: TestDeleteItemOptions = 1
+        testDeleteItemOptions
       })
 
       it('no auto-execution', () => {
@@ -432,6 +496,14 @@ describe('Entity', () => {
         type TestPutItem2 = A.Equals<PutItem2, ExpectedItem | undefined>
         const testPutItem2: TestPutItem2 = 1
         testPutItem2
+
+        type PutItemOptions = PutOptions<typeof ent>
+        type TestPutItemOptions = A.Equals<
+          PutItemOptions,
+          ExpectedWriteOpts<keyof ExpectedItem, 'NONE' | 'ALL_OLD'>
+        >
+        const testPutItemOptions: TestPutItemOptions = 1
+        testPutItemOptions
       })
 
       it('no auto-execution', () => {
@@ -539,6 +611,17 @@ describe('Entity', () => {
         type TestUpdateItem2 = A.Equals<UpdateItem2, ExpectedItem | undefined>
         const testUpdateItem2: TestUpdateItem2 = 1
         testUpdateItem2
+
+        type UpdateItemOptions = UpdateOptions<typeof ent>
+        type TestUpdateItemOptions = A.Equals<
+          UpdateItemOptions,
+          ExpectedWriteOpts<
+            keyof ExpectedItem,
+            'NONE' | 'UPDATED_OLD' | 'UPDATED_NEW' | 'ALL_OLD' | 'ALL_NEW'
+          >
+        >
+        const testUpdateItemOptions: TestUpdateItemOptions = 1
+        testUpdateItemOptions
       })
 
       it('no auto-execution', () => {
@@ -635,6 +718,24 @@ describe('Entity', () => {
       ).toThrow()
       // @ts-expect-error
       ;() => ent.update({ pk }, { conditions: { attr: 'sk', exists: true } })
+    })
+
+    describe('query method', () => {
+      it('nominal case', () => {
+        const queryPromise = () => ent.query('pk')
+        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
+        const testQueryItems: TestQueryItems = 1
+        testQueryItems
+
+        type QueryItemsOptions = QueryOptions<typeof ent>
+        type TestQueryItemsOptions = A.Equals<
+          QueryItemsOptions,
+          ExpectedQueryOpts<keyof ExpectedItem>
+        >
+        const testQueryItemsOptions: TestQueryItemsOptions = 1
+        testQueryItemsOptions
+      })
     })
   })
 
@@ -747,6 +848,11 @@ describe('Entity', () => {
         type TestGetItem4 = A.Equals<GetItem4, ExpectedItem | undefined>
         const testGetItem4: TestGetItem4 = 1
         testGetItem4
+
+        type GetItemOptions = GetOptions<typeof ent>
+        type TestGetItemOptions = A.Equals<GetItemOptions, ExpectedGetOpts<keyof ExpectedItem>>
+        const testGetItemOptions: TestGetItemOptions = 1
+        testGetItemOptions
       })
 
       it('filtered attributes', () => {
@@ -837,6 +943,14 @@ describe('Entity', () => {
         type TestDeleteItem4 = A.Equals<DeleteItem4, ExpectedItem | undefined>
         const testDeleteItem4: TestDeleteItem4 = 1
         testDeleteItem4
+
+        type DeleteItemOptions = DeleteOptions<typeof ent>
+        type TestDeleteItemOptions = A.Equals<
+          DeleteItemOptions,
+          ExpectedWriteOpts<keyof ExpectedItem, 'NONE' | 'ALL_OLD'>
+        >
+        const testDeleteItemOptions: TestDeleteItemOptions = 1
+        testDeleteItemOptions
       })
 
       it('throws when primary key is incomplete', () => {
@@ -935,6 +1049,14 @@ describe('Entity', () => {
         type TestPutItem6 = A.Equals<PutItem6, ExpectedItem | undefined>
         const testPutItem6: TestPutItem6 = 1
         testPutItem6
+
+        type PutItemOptions = PutOptions<typeof ent>
+        type TestPutItemOptions = A.Equals<
+          PutItemOptions,
+          ExpectedWriteOpts<keyof ExpectedItem, 'NONE' | 'ALL_OLD'>
+        >
+        const testPutItemOptions: TestPutItemOptions = 1
+        testPutItemOptions
       })
 
       it('throws when primary key is incomplete', () => {
@@ -1070,6 +1192,17 @@ describe('Entity', () => {
         type TestUpdateItem6 = A.Equals<UpdateItem6, ExpectedItem | undefined>
         const testUpdateItem6: TestUpdateItem6 = 1
         testUpdateItem6
+
+        type UpdateItemOptions = UpdateOptions<typeof ent>
+        type TestUpdateItemOptions = A.Equals<
+          UpdateItemOptions,
+          ExpectedWriteOpts<
+            keyof ExpectedItem,
+            'NONE' | 'UPDATED_OLD' | 'UPDATED_NEW' | 'ALL_OLD' | 'ALL_NEW'
+          >
+        >
+        const testUpdateItemOptions: TestUpdateItemOptions = 1
+        testUpdateItemOptions
       })
 
       it('attribute deletion nominal case', () => {
@@ -1223,6 +1356,24 @@ describe('Entity', () => {
             // @ts-expect-error
             { conditions: { attr: 'incorrectAttr', exists: true } }
           )
+      })
+    })
+
+    describe('query method', () => {
+      it('nominal case', () => {
+        const queryPromise = () => ent.query('pk')
+        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
+        const testQueryItems: TestQueryItems = 1
+        testQueryItems
+
+        type QueryItemsOptions = QueryOptions<typeof ent>
+        type TestQueryItemsOptions = A.Equals<
+          QueryItemsOptions,
+          ExpectedQueryOpts<keyof ExpectedItem>
+        >
+        const testQueryItemsOptions: TestQueryItemsOptions = 1
+        testQueryItemsOptions
       })
     })
   })
@@ -1612,6 +1763,14 @@ describe('Entity', () => {
           // @ts-expect-error
           ;() => ent.get(ck0, { attributes: ['pk'] })
           ;() => ent.get(ck0, { attributes: ['pk0'] })
+
+          type GetItemOptions = GetOptions<typeof ent>
+          type TestGetItemOptions = A.Equals<
+            GetItemOptions,
+            ExpectedGetOpts<keyof EntityItemOverlay>
+          >
+          const testGetItemOptions: TestGetItemOptions = 1
+          testGetItemOptions
         })
 
         it('returned Item should match EntityItemOverlay, even filtered', () => {
@@ -1708,6 +1867,14 @@ describe('Entity', () => {
           // @ts-expect-error
           ;() => ent.delete(ck0, { conditions: { attr: 'pk', exists: true } })
           ;() => ent.delete(ck0, { conditions: { attr: 'pk0', exists: true } })
+
+          type DeleteItemOptions = DeleteOptions<typeof ent>
+          type TestDeleteItemOptions = A.Equals<
+            DeleteItemOptions,
+            ExpectedWriteOpts<keyof EntityItemOverlay, 'NONE' | 'ALL_OLD'>
+          >
+          const testDeleteItemOptions: TestDeleteItemOptions = 1
+          testDeleteItemOptions
         })
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
@@ -1827,6 +1994,14 @@ describe('Entity', () => {
               { conditions: { attr: 'pk', exists: true } }
             )
           ;() => ent.put({ ...ck0, num0 }, { conditions: { attr: 'pk0', exists: true } })
+
+          type PutItemOptions = PutOptions<typeof ent>
+          type TestPutItemOptions = A.Equals<
+            PutItemOptions,
+            ExpectedWriteOpts<keyof EntityItemOverlay, 'NONE' | 'ALL_OLD'>
+          >
+          const testPutItemOptions: TestPutItemOptions = 1
+          testPutItemOptions
         })
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
@@ -1912,6 +2087,17 @@ describe('Entity', () => {
               { conditions: { attr: 'pk', exists: true } }
             )
           ;() => ent.update({ ...ck0, num0 }, { conditions: { attr: 'pk0', exists: true } })
+
+          type UpdateItemOptions = UpdateOptions<typeof ent>
+          type TestUpdateItemOptions = A.Equals<
+            UpdateItemOptions,
+            ExpectedWriteOpts<
+              keyof EntityItemOverlay,
+              'NONE' | 'UPDATED_OLD' | 'UPDATED_NEW' | 'ALL_OLD' | 'ALL_NEW'
+            >
+          >
+          const testUpdateItemOptions: TestUpdateItemOptions = 1
+          testUpdateItemOptions
         })
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
@@ -2038,6 +2224,14 @@ describe('Entity', () => {
           type TestQueryItem = A.Equals<QueryItem, EntityItemOverlay[] | undefined>
           const testQueryItem: TestQueryItem = 1
           testQueryItem
+
+          type QueryItemsOptions = QueryOptions<typeof ent>
+          type TestQueryItemsOptions = A.Equals<
+            QueryItemsOptions,
+            ExpectedQueryOpts<keyof EntityItemOverlay>
+          >
+          const testQueryItemsOptions: TestQueryItemsOptions = 1
+          testQueryItemsOptions
 
           const filteredQueryPromise = () => ent.query('pk', { attributes: ['pk0', 'sk0', 'str0'] })
           type FilteredQueryItem = C.PromiseOf<F.Return<typeof filteredQueryPromise>>['Items']

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -183,6 +183,17 @@ describe('Entity', () => {
       table: tableWithoutSK
     } as const)
 
+    const entNoTimestamps = new Entity({
+      name: entityName,
+      timestamps: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
     type ExpectedItem = {
       created: string
       modified: string
@@ -254,6 +265,18 @@ describe('Entity', () => {
         type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
         const testGetRawResponse: TestGetRawResponse = 1
         testGetRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const getPromise = () => entNoTimestamps.get(item)
+        type GetResponse = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetResponse = A.Equals<
+          GetResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testGetResponse: TestGetResponse = 1
+        testGetResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -355,6 +378,18 @@ describe('Entity', () => {
         testDeleteRawResponse
       })
 
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const deletePromise = () => entNoTimestamps.delete(item, { returnValues: 'ALL_OLD' })
+        type DeleteResponse = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteResponse = A.Equals<
+          DeleteResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testDeleteResponse: TestDeleteResponse = 1
+        testDeleteResponse
+      })
+
       it('throws when primary key is incomplete', () => {
         // @ts-expect-error
         expect(() => ent.deleteParams({})).toThrow()
@@ -451,6 +486,18 @@ describe('Entity', () => {
         type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
         const testPutRawResponse: TestPutRawResponse = 1
         testPutRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const putPromise = () => entNoTimestamps.put(item, { returnValues: 'ALL_OLD' })
+        type PutResponse = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutResponse = A.Equals<
+          PutResponse,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testPutResponse: TestPutResponse = 1
+        testPutResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -554,6 +601,18 @@ describe('Entity', () => {
         >
         const testUpdateRawResponse: TestUpdateRawResponse = 1
         testUpdateRawResponse
+      })
+
+      it('contains no timestamp', () => {
+        const item = { pk }
+        const updatePromise = () => entNoTimestamps.update(item, { returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<
+          UpdateItem,
+          Omit<ExpectedItem, 'created' | 'modified'> | undefined
+        >
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
       })
 
       it('throws when primary key is incomplete', () => {

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -1,4 +1,5 @@
 import { DynamoDB } from 'aws-sdk'
+import { DocumentClient as DocumentClientType } from 'aws-sdk/clients/dynamodb'
 import MockDate from 'mockdate'
 import { A, C, F, O } from 'ts-toolbelt'
 
@@ -160,6 +161,28 @@ describe('Entity', () => {
       table: tableWithoutSK
     } as const)
 
+    const entNoExecute = new Entity({
+      name: entityName,
+      autoExecute: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
+    const entNoParse = new Entity({
+      name: entityName,
+      autoParse: false,
+      attributes: {
+        pk: { type: 'string', partitionKey: true, hidden: true },
+        pkMap1: ['pk', 0],
+        pkMap2: ['pk', 1]
+      },
+      table: tableWithoutSK
+    } as const)
+
     type ExpectedItem = {
       created: string
       modified: string
@@ -177,6 +200,60 @@ describe('Entity', () => {
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const getPromise = () => entNoExecute.get(item)
+        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
+        const testGetParams: TestGetParams = 1
+        testGetParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const getPromise = () => entNoExecute.get(item, { execute: true })
+        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
+        const testGetItem: TestGetItem = 1
+        testGetItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const getPromise = () => ent.get(item, { execute: false })
+        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
+        const testGetParams: TestGetParams = 1
+        testGetParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const getPromise = () => entNoParse.get(item)
+        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
+        const testGetRawResponse: TestGetRawResponse = 1
+        testGetRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const getPromise = () => entNoParse.get(item, { parse: true })
+        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
+        const testGetItem: TestGetItem = 1
+        testGetItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const getPromise = () => ent.get(item, { parse: false })
+        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
+        const testGetRawResponse: TestGetRawResponse = 1
+        testGetRawResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -214,6 +291,68 @@ describe('Entity', () => {
         type TestDeleteItem2 = A.Equals<DeleteItem2, ExpectedItem | undefined>
         const testDeleteItem2: TestDeleteItem2 = 1
         testDeleteItem2
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const deletePromise = () => entNoExecute.delete(item)
+        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
+        const testDeleteParams: TestDeleteParams = 1
+        testDeleteParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const deletePromise = () =>
+          entNoExecute.delete(item, { execute: true, returnValues: 'ALL_OLD' })
+        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
+        const testDeleteItem: TestDeleteItem = 1
+        testDeleteItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const deletePromise = () => ent.delete(item, { execute: false })
+        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
+        const testDeleteParams: TestDeleteParams = 1
+        testDeleteParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const deletePromise = () => entNoParse.delete(item)
+        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteRawResponse = A.Equals<
+          DeleteRawResponse,
+          DocumentClientType.DeleteItemOutput
+        >
+        const testDeleteRawResponse: TestDeleteRawResponse = 1
+        testDeleteRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const deletePromise = () =>
+          entNoParse.delete(item, { parse: true, returnValues: 'ALL_OLD' })
+        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
+        const testDeleteItem: TestDeleteItem = 1
+        testDeleteItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const deletePromise = () => ent.update(item, { parse: false })
+        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type TestDeleteRawResponse = A.Equals<
+          DeleteRawResponse,
+          DocumentClientType.DeleteItemOutput
+        >
+        const testDeleteRawResponse: TestDeleteRawResponse = 1
+        testDeleteRawResponse
       })
 
       it('throws when primary key is incomplete', () => {
@@ -260,6 +399,60 @@ describe('Entity', () => {
         testPutItem2
       })
 
+      it('no auto-execution', () => {
+        const item = { pk }
+        const putPromise = () => entNoExecute.put(item)
+        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
+        const testPutParams: TestPutParams = 1
+        testPutParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const putPromise = () => entNoExecute.put(item, { execute: true, returnValues: 'ALL_OLD' })
+        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
+        const testPutItem: TestPutItem = 1
+        testPutItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const putPromise = () => ent.put(item, { execute: false, returnValues: 'ALL_OLD' })
+        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
+        const testPutParams: TestPutParams = 1
+        testPutParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const putPromise = () => entNoParse.put(item)
+        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
+        const testPutRawResponse: TestPutRawResponse = 1
+        testPutRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const putPromise = () => entNoParse.put(item, { parse: true, returnValues: 'ALL_OLD' })
+        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
+        const testPutItem: TestPutItem = 1
+        testPutItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const putPromise = () => ent.put(item, { parse: false })
+        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
+        const testPutRawResponse: TestPutRawResponse = 1
+        testPutRawResponse
+      })
+
       it('throws when primary key is incomplete', () => {
         // @ts-expect-error
         expect(() => ent.putParams({})).toThrow()
@@ -299,6 +492,68 @@ describe('Entity', () => {
         type TestUpdateItem2 = A.Equals<UpdateItem2, ExpectedItem | undefined>
         const testUpdateItem2: TestUpdateItem2 = 1
         testUpdateItem2
+      })
+
+      it('no auto-execution', () => {
+        const item = { pk }
+        const updatePromise = () => entNoExecute.update(item)
+        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
+        const testUpdateParams: TestUpdateParams = 1
+        testUpdateParams
+      })
+
+      it('force execution', () => {
+        const item = { pk }
+        const updatePromise = () =>
+          entNoExecute.update(item, { execute: true, returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
+      })
+
+      it('force no execution', () => {
+        const item = { pk }
+        const updatePromise = () => ent.update(item, { execute: false })
+        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
+        const testUpdateParams: TestUpdateParams = 1
+        testUpdateParams
+      })
+
+      it('no auto-parsing', () => {
+        const item = { pk }
+        const updatePromise = () => entNoParse.update(item)
+        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateRawResponse = A.Equals<
+          UpdateRawResponse,
+          DocumentClientType.UpdateItemOutput
+        >
+        const testUpdateRawResponse: TestUpdateRawResponse = 1
+        testUpdateRawResponse
+      })
+
+      it('force parsing', () => {
+        const item = { pk }
+        const updatePromise = () =>
+          entNoParse.update(item, { parse: true, returnValues: 'ALL_NEW' })
+        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
+        const testUpdateItem: TestUpdateItem = 1
+        testUpdateItem
+      })
+
+      it('force no parsing', () => {
+        const item = { pk }
+        const updatePromise = () => ent.update(item, { parse: false })
+        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type TestUpdateRawResponse = A.Equals<
+          UpdateRawResponse,
+          DocumentClientType.UpdateItemOutput
+        >
+        const testUpdateRawResponse: TestUpdateRawResponse = 1
+        testUpdateRawResponse
       })
 
       it('throws when primary key is incomplete', () => {

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -16,11 +16,17 @@ import getKey from '../lib/getKey'
 import parseConditions from '../lib/expressionBuilder'
 import parseProjections from '../lib/projectionBuilder'
 import { error, transformAttr, isEmpty, If, PreventKeys, FirstDefined } from '../lib/utils'
-import { DynamoDBKeyTypes, DynamoDBTypes, QueryOptions, ScanOptions, TableType } from './Table'
+import {
+  DynamoDBKeyTypes,
+  DynamoDBTypes,
+  AttributesQueryOptions,
+  ScanOptions,
+  TableDef
+} from './Table'
 
 // Definitions
 export interface EntityConstructor<
-  EntityTable extends TableType | undefined = undefined,
+  EntityTable extends TableDef | undefined = undefined,
   Name extends string = string,
   AutoExecute extends boolean = true,
   AutoParse extends boolean = true,
@@ -326,7 +332,7 @@ type BaseOptions<
   parse: Parse
 }
 
-export type ReadOptions<
+export type AttributesReadOptions<
   Attributes extends A.Key = A.Key,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
@@ -337,13 +343,13 @@ export type ReadOptions<
   consistent: boolean
 }
 
-type GetOptions<
+type AttributesGetOptions<
   Attributes extends A.Key = A.Key,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
-> = O.Partial<ReadOptions<Attributes, Execute, Parse> & { include: string[] }>
+> = O.Partial<AttributesReadOptions<Attributes, Execute, Parse> & { include: string[] }>
 
-type WriteOptions<
+type AttributesWriteOptions<
   Attributes extends A.Key = A.Key,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
@@ -355,12 +361,12 @@ type WriteOptions<
 
 type PutOptionsReturnValues = 'NONE' | 'ALL_OLD'
 
-type PutOptions<
+type AttributesPutOptions<
   Attributes extends A.Key = A.Key,
   ReturnValues extends PutOptionsReturnValues = PutOptionsReturnValues,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
-> = O.Partial<WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
+> = O.Partial<AttributesWriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
 
 type PutItem<
   MethodItemOverlay extends Overlay,
@@ -389,12 +395,12 @@ type PutItem<
 
 type UpdateOptionsReturnValues = 'NONE' | 'UPDATED_OLD' | 'UPDATED_NEW' | 'ALL_OLD' | 'ALL_NEW'
 
-type UpdateOptions<
+type AttributesUpdateOptions<
   Attributes extends A.Key = A.Key,
   ReturnValues extends UpdateOptionsReturnValues = UpdateOptionsReturnValues,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
-> = O.Partial<WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
+> = O.Partial<AttributesWriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
 
 interface UpdateCustomParameters {
   SET: string[]
@@ -436,12 +442,12 @@ type UpdateItem<
 
 type DeleteOptionsReturnValues = 'NONE' | 'ALL_OLD'
 
-type DeleteOptions<
+type RawDeleteOptions<
   Attributes extends A.Key = A.Key,
   ReturnValues extends DeleteOptionsReturnValues = DeleteOptionsReturnValues,
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined
-> = O.Partial<WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
+> = O.Partial<AttributesWriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
 
 type TransactionOptionsReturnValues = 'NONE' | 'ALL_OLD'
 
@@ -472,7 +478,7 @@ export const shouldParse = (parse: boolean | undefined, autoParse: boolean): boo
 class Entity<
   EntityItemOverlay extends Overlay = undefined,
   EntityCompositeKeyOverlay extends Overlay = EntityItemOverlay,
-  EntityTable extends TableType | undefined = undefined,
+  EntityTable extends TableDef | undefined = undefined,
   Name extends string = string,
   AutoExecute extends boolean = true,
   AutoParse extends boolean = true,
@@ -521,6 +527,13 @@ class Entity<
   public defaults: any
   public linked: any
   public required: any
+  // @ts-ignore
+  public _typesOnly: { _entityItemOverlay: EntityItemOverlay }
+  public attributes: ReadonlyAttributeDefinitions
+  public timestamps: Timestamps
+  public createdAlias: CreatedAlias
+  public modifiedAlias: ModifiedAlias
+  public typeAlias: TypeAlias
 
   // Declare constructor (entity config)
   constructor(
@@ -540,6 +553,18 @@ class Entity<
     if (typeof entity !== 'object' || Array.isArray(entity))
       error('Please provide a valid entity definition')
 
+    const {
+      attributes,
+      timestamps = true,
+      createdAlias = 'created',
+      modifiedAlias = 'modified',
+      typeAlias = 'entity'
+    } = entity
+    this.attributes = attributes
+    this.timestamps = timestamps as Timestamps
+    this.createdAlias = createdAlias as CreatedAlias
+    this.modifiedAlias = modifiedAlias as ModifiedAlias
+    this.typeAlias = typeAlias as TypeAlias
     // Parse the entity and merge into this
     Object.assign(this, parseEntity(entity))
   } // end construcor
@@ -697,7 +722,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: FirstDefined<[MethodCompositeKeyOverlay, EntityCompositeKeyOverlay, CompositePrimaryKey]>,
-    options: GetOptions<ResponseAttributes, Execute, Parse> = {},
+    options: AttributesGetOptions<ResponseAttributes, Execute, Parse> = {},
     params: Partial<DocumentClient.GetItemInput> = {}
   ): Promise<
     If<
@@ -842,7 +867,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: FirstDefined<[MethodCompositeKeyOverlay, EntityCompositeKeyOverlay, CompositePrimaryKey]>,
-    options: GetOptions<ResponseAttributes, Execute, Parse> = {},
+    options: AttributesGetOptions<ResponseAttributes, Execute, Parse> = {},
     params: Partial<DocumentClient.GetItemInput> = {}
   ): DocumentClient.GetItemInput {
     // Extract schema and merge defaults
@@ -935,7 +960,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: FirstDefined<[MethodCompositeKeyOverlay, EntityCompositeKeyOverlay, CompositePrimaryKey]>,
-    options: DeleteOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: RawDeleteOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     params: Partial<DocumentClient.DeleteItemInput> = {}
   ): Promise<
     If<
@@ -1071,7 +1096,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: FirstDefined<[MethodCompositeKeyOverlay, EntityCompositeKeyOverlay, CompositePrimaryKey]>,
-    options: DeleteOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: RawDeleteOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     params: Partial<DocumentClient.DeleteItemInput> = {}
   ): DocumentClient.DeleteItemInput {
     // Extract schema and merge defaults
@@ -1180,7 +1205,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: UpdateItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes>,
-    options: UpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: AttributesUpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     params: Partial<DocumentClient.UpdateItemInput> = {}
   ): Promise<
     A.Compute<
@@ -1297,7 +1322,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: UpdateItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes>,
-    options: UpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: AttributesUpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     {
       SET = [],
       REMOVE = [],
@@ -1633,7 +1658,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes>,
-    options: PutOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: AttributesPutOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     params: Partial<DocumentClient.PutItemInput> = {}
   ): Promise<
     If<
@@ -1760,7 +1785,7 @@ class Entity<
     Parse extends boolean | undefined = undefined
   >(
     item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes>,
-    options: PutOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
+    options: AttributesPutOptions<ResponseAttributes, ReturnValues, Execute, Parse> = {},
     params: Partial<DocumentClient.PutItemInput> = {}
   ): DocumentClient.PutItemInput {
     // Extract schema and defaults
@@ -1952,7 +1977,7 @@ class Entity<
     FiltersAttributes extends ItemAttributes = ResponseAttributes
   >(
     pk: any,
-    options: QueryOptions<ResponseAttributes, FiltersAttributes> = {},
+    options: AttributesQueryOptions<ResponseAttributes, FiltersAttributes> = {},
     params: Partial<DocumentClient.QueryInput> = {}
   ) {
     if (!this.table) {
@@ -1980,3 +2005,40 @@ class Entity<
 
 // Export the Entity class
 export default Entity
+
+type EntityDef = {
+  _typesOnly: { _entityItemOverlay: Overlay }
+  timestamps: boolean
+  createdAlias: string
+  modifiedAlias: string
+  typeAlias: string
+  attributes: AttributeDefinitions | O.Readonly<AttributeDefinitions, A.Key, 'deep'>
+}
+
+type ExtractAttributes<E extends EntityDef> = E['_typesOnly']['_entityItemOverlay'] extends Record<
+  A.Key,
+  any
+>
+  ? keyof E['_typesOnly']['_entityItemOverlay']
+  : ParseAttributes<
+      A.Cast<O.Writable<E['attributes'], A.Key, 'deep'>, AttributeDefinitions>,
+      E['timestamps'],
+      E['createdAlias'],
+      E['modifiedAlias'],
+      E['typeAlias']
+    >['all']
+
+export type GetOptions<E extends EntityDef, A extends A.Key = ExtractAttributes<E>> =
+  AttributesGetOptions<A, boolean | undefined, boolean | undefined>
+
+export type QueryOptions<E extends EntityDef, A extends A.Key = ExtractAttributes<E>> =
+  AttributesQueryOptions<A, A, boolean | undefined, boolean | undefined>
+
+export type PutOptions<E extends EntityDef, A extends A.Key = ExtractAttributes<E>> =
+  AttributesPutOptions<A, PutOptionsReturnValues, boolean | undefined, boolean | undefined>
+
+export type DeleteOptions<E extends EntityDef, A extends A.Key = ExtractAttributes<E>> =
+  RawDeleteOptions<A, DeleteOptionsReturnValues, boolean | undefined, boolean | undefined>
+
+export type UpdateOptions<E extends EntityDef, A extends A.Key = ExtractAttributes<E>> =
+  AttributesUpdateOptions<A, UpdateOptionsReturnValues, boolean | undefined, boolean | undefined>

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,12 @@
 
 import Table from './classes/Table'
 import Entity from './classes/Entity'
+import type {
+  GetOptions,
+  QueryOptions,
+  PutOptions,
+  DeleteOptions,
+  UpdateOptions
+} from './classes/Entity'
 
-export { Table, Entity }
+export { Table, Entity, GetOptions, QueryOptions, PutOptions, DeleteOptions, UpdateOptions }

--- a/src/lib/expressionBuilder.ts
+++ b/src/lib/expressionBuilder.ts
@@ -12,7 +12,7 @@ import { A } from 'ts-toolbelt'
 
 import checkAttribute from './checkAttribute'
 import { error } from './utils'
-import { TableType } from '../classes/Table'
+import { TableDef } from '../classes/Table'
 
 interface FilterExpression<Attr extends A.Key = A.Key> {
   attr?: Attr
@@ -41,7 +41,7 @@ export type FilterExpressions<Attr extends A.Key = A.Key> =
 
 const buildExpression = <
   Attr extends A.Key = A.Key,
-  EntityTable extends TableType | undefined = undefined
+  EntityTable extends TableDef | undefined = undefined
 >(
   exp: FilterExpressions<Attr>,
   table: EntityTable,
@@ -115,7 +115,7 @@ const conditionError = (op?: string) =>
   error(`You can only supply one filter condition per query. Already using '${op}'`)
 
 // Parses expression clause and returns structured clause object
-const parseClause = <EntityTable extends TableType | undefined = undefined>(
+const parseClause = <EntityTable extends TableDef | undefined = undefined>(
   _clause: FilterExpression,
   grp: number,
   table: EntityTable

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -38,6 +38,8 @@ export function parseEntity<
   CreatedAlias extends string,
   ModifiedAlias extends string,
   TypeAlias extends string,
+  AutoExecute extends boolean,
+  AutoParse extends boolean,
   ReadonlyAttributeDefinitions extends PreventKeys<
     AttributeDefinitions | O.Readonly<AttributeDefinitions, A.Key, 'deep'>,
     CreatedAlias | ModifiedAlias | TypeAlias
@@ -49,6 +51,8 @@ export function parseEntity<
     CreatedAlias,
     ModifiedAlias,
     TypeAlias,
+    AutoExecute,
+    AutoParse,
     ReadonlyAttributeDefinitions
   >
 ) {

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -35,11 +35,12 @@ export type ParsedEntity = ReturnType<typeof parseEntity>
 export function parseEntity<
   EntityTable extends TableType | undefined,
   Name extends string,
+  AutoExecute extends boolean,
+  AutoParse extends boolean,
+  Timestamps extends boolean,
   CreatedAlias extends string,
   ModifiedAlias extends string,
   TypeAlias extends string,
-  AutoExecute extends boolean,
-  AutoParse extends boolean,
   ReadonlyAttributeDefinitions extends PreventKeys<
     AttributeDefinitions | O.Readonly<AttributeDefinitions, A.Key, 'deep'>,
     CreatedAlias | ModifiedAlias | TypeAlias
@@ -48,11 +49,12 @@ export function parseEntity<
   entity: EntityConstructor<
     EntityTable,
     Name,
+    AutoExecute,
+    AutoParse,
+    Timestamps,
     CreatedAlias,
     ModifiedAlias,
     TypeAlias,
-    AutoExecute,
-    AutoParse,
     ReadonlyAttributeDefinitions
   >
 ) {
@@ -79,36 +81,43 @@ export function parseEntity<
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Entity name
-  name = (typeof name === 'string' && name.trim().length > 0
-    ? name.trim()
-    : error(`'name' must be defined`)) as Name
+  name = (
+    typeof name === 'string' && name.trim().length > 0
+      ? name.trim()
+      : error(`'name' must be defined`)
+  ) as Name
 
+  // 🔨 TOIMPROVE: Use default option & simply throw if type is incorrect
   // Enable created/modified timestamps on items
-  timestamps = typeof timestamps === 'boolean' ? timestamps : true
+  timestamps = (typeof timestamps === 'boolean' ? timestamps : true) as Timestamps
 
   // Define 'created' attribute name
   created = typeof created === 'string' && created.trim().length > 0 ? created.trim() : '_ct'
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'createdAlias'
-  createdAlias = (typeof createdAlias === 'string' && createdAlias.trim().length > 0
-    ? createdAlias.trim()
-    : 'created') as CreatedAlias
+  createdAlias = (
+    typeof createdAlias === 'string' && createdAlias.trim().length > 0
+      ? createdAlias.trim()
+      : 'created'
+  ) as CreatedAlias
 
   // Define 'modified' attribute anme
   modified = typeof modified === 'string' && modified.trim().length > 0 ? modified.trim() : '_md'
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'modifiedAlias'
-  modifiedAlias = (typeof modifiedAlias === 'string' && modifiedAlias.trim().length > 0
-    ? modifiedAlias.trim()
-    : 'modified') as ModifiedAlias
+  modifiedAlias = (
+    typeof modifiedAlias === 'string' && modifiedAlias.trim().length > 0
+      ? modifiedAlias.trim()
+      : 'modified'
+  ) as ModifiedAlias
 
   // 🔨 TOIMPROVE: Not triming would be better for type safety (no need to cast)
   // Define 'entityAlias'
-  typeAlias = (typeof typeAlias === 'string' && typeAlias.trim().length > 0
-    ? typeAlias.trim()
-    : 'entity') as TypeAlias
+  typeAlias = (
+    typeof typeAlias === 'string' && typeAlias.trim().length > 0 ? typeAlias.trim() : 'entity'
+  ) as TypeAlias
 
   // Sanity check the attributes
   attributes =

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -8,7 +8,7 @@
 import { A, O } from 'ts-toolbelt'
 
 import parseEntityAttributes from './parseEntityAttributes'
-import { TableType } from '../classes/Table'
+import { TableDef } from '../classes/Table'
 import { AttributeDefinitions, EntityConstructor } from '../classes/Entity'
 import { error, PreventKeys } from './utils'
 
@@ -33,7 +33,7 @@ export type ParsedEntity = ReturnType<typeof parseEntity>
 
 // Parse entity
 export function parseEntity<
-  EntityTable extends TableType | undefined,
+  EntityTable extends TableDef | undefined,
   Name extends string,
   AutoExecute extends boolean,
   AutoParse extends boolean,

--- a/src/lib/parseEntityAttributes.ts
+++ b/src/lib/parseEntityAttributes.ts
@@ -29,7 +29,7 @@ const parseEntityAttributes = <
 
     // If a string value
     if (typeof attributeDefinition === 'string') {
-      if (isDynamoDbType(attributeDefinition as string)) {
+      if (isDynamoDbType(attributeDefinition)) {
         // Merge and return mapping
         return Object.assign(acc, parseMapping(field, { type: attributeDefinition }, track))
       } else {

--- a/src/lib/parseMapping.ts
+++ b/src/lib/parseMapping.ts
@@ -6,7 +6,9 @@
 
 import {
   PartitionKeyDefinition,
+  GSIPartitionKeyDefinition,
   SortKeyDefinition,
+  GSISortKeyDefinition,
   PureAttributeDefinition
 } from '../classes/Entity'
 import { TrackingInfo } from './parseEntity'
@@ -15,7 +17,12 @@ import { error } from './utils'
 // Parse and validate mapping config
 export default (
   field: string,
-  config: PartitionKeyDefinition | SortKeyDefinition | PureAttributeDefinition,
+  config:
+    | PartitionKeyDefinition
+    | GSIPartitionKeyDefinition
+    | SortKeyDefinition
+    | GSISortKeyDefinition
+    | PureAttributeDefinition,
   track: TrackingInfo
 ) => {
   // Validate props

--- a/src/lib/projectionBuilder.ts
+++ b/src/lib/projectionBuilder.ts
@@ -9,7 +9,7 @@
 import { A } from 'ts-toolbelt'
 
 // Import standard error handler
-import { TableType } from '../classes/Table'
+import { TableDef } from '../classes/Table'
 import { error } from './utils'
 import checkAttribute from './checkAttribute'
 
@@ -25,7 +25,7 @@ export type ProjectionAttributes =
   | (A.Key | ProjectionAttributeType)[]
 export type ProjectionAttributeType = { [key: string]: string | string[] }
 
-const projectionBuilder = <EntityTable extends TableType | undefined>(
+const projectionBuilder = <EntityTable extends TableDef | undefined>(
   attributes: ProjectionAttributes,
   table: EntityTable,
   entity: string | null,


### PR DESCRIPTION
Sometimes it can be useful to dynamically set an entity operation options. For instance:

```
const queryOptions = {};

if (!isSuperadmin(user)) {
  queryOptions.beginsWith = 'USER'
}

const { Item } = await myEntity.query(pk, { attributes: ['name', 'age'], ...queryOptions })
```

Sadly, in TS this will throw an error, as `getOptions` is typed as `{}` by default. Using a non-generic `GetOptions` type will also throw an error because the entity attribute names are hardly typed now, and `string` will not be assignable to either the `attributes` or `conditions` options.

This PR proposes to solve this problem by exposing `GetOptions`, `PutOptions`, `DeleteOptions`, `UpdateOptions` & `QueryOptions` utility types:

```
import type { QueryOptions } from 'dynamodb-toolbox'

const queryOptions: QueryOptions<typeof myEntity> = {};

if (!isSuperadmin(user)) {
  queryOptions.beginsWith = 'USER'
}

const { Item } = await myEntity.query(pk, { attributes: ['name', 'age'], ...queryOptions })
```

WDYT ?