### PR TITLE
fix: export Writable type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dynamodb-toolbox",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dynamodb-toolbox",
-      "version": "0.4.0-alpha.1",
+      "version": "0.4.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "ts-toolbelt": "^6.15.5"

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -451,23 +451,20 @@ type UpdateItem<
     MethodItemOverlay,
     EntityItemOverlay,
     A.Compute<
-      CompositePrimaryKey &
-        {
-          [inputAttr in Attributes['always']['input']]:
-            | Item[A.Cast<inputAttr, keyof Item>]
-            | { $delete?: string[]; $add?: any }
-        } &
-        {
-          [optAttr in Attributes['required']['all'] | Attributes['always']['default']]?:
-            | Item[A.Cast<optAttr, keyof Item>]
-            | { $delete?: string[]; $add?: any }
-        } &
-        {
-          [attr in Attributes['optional']]?:
-            | null
-            | Item[A.Cast<attr, keyof Item>]
-            | { $delete?: string[]; $add?: any }
-        } & { $remove?: Attributes['optional'] | Attributes['optional'][] }
+      CompositePrimaryKey & {
+        [inputAttr in Attributes['always']['input']]:
+          | Item[A.Cast<inputAttr, keyof Item>]
+          | { $delete?: string[]; $add?: any }
+      } & {
+        [optAttr in Attributes['required']['all'] | Attributes['always']['default']]?:
+          | Item[A.Cast<optAttr, keyof Item>]
+          | { $delete?: string[]; $add?: any }
+      } & {
+        [attr in Attributes['optional']]?:
+          | null
+          | Item[A.Cast<attr, keyof Item>]
+          | { $delete?: string[]; $add?: any }
+      } & { $remove?: Attributes['optional'] | Attributes['optional'][] }
     >
   ]
 >
@@ -507,7 +504,7 @@ export const shouldParse = (parse: boolean | undefined, autoParse: boolean): boo
   parse === true || (parse === undefined && autoParse)
 
 type Readonly<T> = T extends O.Object ? { readonly [P in keyof T]: Readonly<T[P]> } : T
-type Writable<T> = { -readonly [P in keyof T]: Writable<T[P]> }
+export type Writable<T> = { -readonly [P in keyof T]: Writable<T[P]> }
 
 // Declare Entity class
 class Entity<


### PR DESCRIPTION
fix this typescript error:
```
Exported variable '<MyEntity>' has or is using name 'Writable' from external module "<project_path>/node_modules/dynamodb-toolbox/dist/classes/Entity" but cannot be named.
```

Sorry about the extra diff caused by my IDE. I can revert it if needed.