### PR TITLE
Configuration to preserve whitespace-only values

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,19 +270,20 @@ const MyTable = new Table({
 
 `Table` takes a single parameter of type `object` that accepts the following properties:
 
-| Property             |         Type          | Required | Description                                                                                                                        |
-| -------------------- | :-------------------: | :------: | ---------------------------------------------------------------------------------------------------------------------------------- |
-| name                 |       `string`        |   yes    | The name of your DynamoDB table (this will be used as the `TableName` property)                                                    |
-| alias                |       `string`        |    no    | An optional alias to reference your table when using "batch" features                                                              |
-| partitionKey         |       `string`        |   yes    | The attribute name of your table's partitionKey                                                                                    |
-| sortKey              |       `string`        |    no    | The attribute name of your table's sortKey                                                                                         |
-| entityField          | `boolean` or `string` |    no    | Disables or overrides entity tracking field name (default: `_et`)                                                                  |
-| attributes           |       `object`        |    no    | Complex type that optionally specifies the name and type of each attributes (see below)                                            |
-| indexes              |       `object`        |    no    | Complex type that optionally specifies the name keys of your secondary indexes (see below)                                         |
-| autoExecute          |       `boolean`       |    no    | Enables automatic execution of the DocumentClient method (default: `true`)                                                         |
-| autoParse            |       `boolean`       |    no    | Enables automatic parsing of returned data when `autoExecute` is `true` (default: `true`)                                          |
-| removeNullAttributes |       `boolean`       |    no    | Removes null attributes instead of setting them to `null` (default: `true`)                                                        |
-| DocumentClient       |   `DocumentClient`    |    \*    | A valid instance of the AWS [DocumentClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html) |
+| Property              |         Type          | Required | Description                                                                                                                        |
+| --------------------- | :-------------------: | :------: | ---------------------------------------------------------------------------------------------------------------------------------- |
+| name                  |       `string`        |   yes    | The name of your DynamoDB table (this will be used as the `TableName` property)                                                    |
+| alias                 |       `string`        |    no    | An optional alias to reference your table when using "batch" features                                                              |
+| partitionKey          |       `string`        |   yes    | The attribute name of your table's partitionKey                                                                                    |
+| sortKey               |       `string`        |    no    | The attribute name of your table's sortKey                                                                                         |
+| entityField           | `boolean` or `string` |    no    | Disables or overrides entity tracking field name (default: `_et`)                                                                  |
+| attributes            |       `object`        |    no    | Complex type that optionally specifies the name and type of each attributes (see below)                                            |
+| indexes               |       `object`        |    no    | Complex type that optionally specifies the name keys of your secondary indexes (see below)                                         |
+| autoExecute           |       `boolean`       |    no    | Enables automatic execution of the DocumentClient method (default: `true`)                                                         |
+| autoParse             |       `boolean`       |    no    | Enables automatic parsing of returned data when `autoExecute` is `true` (default: `true`)                                          |
+| removeNullAttributes  |       `boolean`       |    no    | Removes null attributes instead of setting them to `null` (default: `true`)                                                        |
+| treatWhitespaceAsNull |       `boolean`       |    no    | Treats whitespace-only values as null (e.g. `' '`) when removing null attributes (default: `true`)                                 |
+| DocumentClient        |   `DocumentClient`    |    \*    | A valid instance of the AWS [DocumentClient](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html) |
 
 \* _A Table can be instantiated without a DocumentClient, but most methods require it before execution_
 

--- a/src/__tests__/entity.update.unit.test.ts
+++ b/src/__tests__/entity.update.unit.test.ts
@@ -67,6 +67,7 @@ const TestTable3 = new Table({
   name: 'test-table3',
   partitionKey: 'pk',
   entityField: false,
+  treatWhitespaceAsNull: false,
   DocumentClient
 })
 
@@ -183,6 +184,14 @@ describe('update',()=>{
     expect(ExpressionAttributeNames).toEqual({ '#test_composite': 'test_composite' })
     expect(Key).toEqual({ pk: 'test-pk' })
     expect(TableName).toBe('test-table2')
+  })
+
+  it('Removes whitespace-only fields by default', () => {
+    let { UpdateExpression } = TestEntity2.updateParams({
+      pk: 'test-pk',
+      test_composite: ' '
+    })
+    expect(UpdateExpression).toBe('REMOVE #test_composite')
   })
 
   it('fails removing an invalid attribute', () => {
@@ -525,6 +534,15 @@ describe('update',()=>{
       test3: 0
     })
     expect(ExpressionAttributeValues![':test3']).toBe(0)
+  })
+
+  it('does not convert whitespace to null', () => {
+    let { ExpressionAttributeValues } = TestEntity3.updateParams({
+      pk: 'test-pk',
+      test2: ' ',
+      test3: 0
+    })
+    expect(ExpressionAttributeValues![':test2']).toBe(' ')
   })
 
   it('fails with undefined input', () => {

--- a/src/classes/Entity.ts
+++ b/src/classes/Entity.ts
@@ -789,7 +789,13 @@ class Entity<
           REMOVE.push(`#${attr}`)
           names[`#${attr}`] = attr
         } // end for
-      } else if (this._table!._removeNulls === true && (data[field] === null || String(data[field]).trim() === '') && (!mapping.link || mapping.save)) {
+      } else if (
+        this._table!._removeNulls === true && 
+        (data[field] === null || (
+          this._table!._trimWhitespaceOnly && String(data[field]).trim() === ''
+        )) && 
+        (!mapping.link || mapping.save)
+      ) {
         REMOVE.push(`#${field}`)
         names[`#${field}`] = field
       } else if (

--- a/src/classes/Table.ts
+++ b/src/classes/Table.ts
@@ -35,6 +35,7 @@ export interface TableConstructor {
   DocumentClient?: DynamoDb.DocumentClient
   entities?: {} // improve - not documented
   removeNullAttributes?: boolean
+  treatWhitespaceAsNull?: boolean
 }
 
 export type DynamoDBTypes = 'string' | 'boolean' | 'number' | 'list' | 'map' | 'binary' | 'set'
@@ -148,6 +149,7 @@ class Table {
   private _execute: boolean = true
   private _parse: boolean = true
   public _removeNulls: boolean = true
+  public _trimWhitespaceOnly: boolean = true
   private _docClient?: DocumentClient
   private _entities: string[] = []
   public Table!: ParsedTable['Table']
@@ -176,14 +178,20 @@ class Table {
   // Sets the auto parse mode (default to true)
   set autoParse(val) { this._parse = typeof val === 'boolean' ? val : true }
 
-  // Gets the current auto execute mode
+  // Gets the current auto parse mode
   get autoParse() { return this._parse }
 
-  // Sets the auto execute mode (default to true)
+  // Sets the remove nulls mode (default to true)
   set removeNullAttributes(val) { this._removeNulls = typeof val === 'boolean' ? val : true }
 
-  // Gets the current auto execute mode
+  // Gets the current remove nulls mode
   get removeNullAttributes() { return this._removeNulls }
+
+  // Sets the mode for treating whitespace as null (default to true)
+  set treatWhitespaceAsNull(val) { this._trimWhitespaceOnly = typeof val === 'boolean' ? val : true }
+
+  // Gets the current mode for treating whitespace as null
+  get treatWhitespaceAsNull() { return this._trimWhitespaceOnly }
 
   // Retrieves the document client
   get DocumentClient() { return this._docClient }

--- a/src/lib/parseTable.ts
+++ b/src/lib/parseTable.ts
@@ -25,6 +25,7 @@ export const parseTable = (table: TableConstructor) => {
     autoExecute,
     autoParse,
     removeNullAttributes,
+    treatWhitespaceAsNull,
     entities,
     DocumentClient,
     ...args // extraneous config
@@ -91,6 +92,7 @@ export const parseTable = (table: TableConstructor) => {
     autoExecute,
     autoParse,
     removeNullAttributes,
+    treatWhitespaceAsNull,
     _entities: [] // init Entity tracker
   },
   DocumentClient ? { DocumentClient } : {}, // end DocumentClient


### PR DESCRIPTION
Fixes #252
Creates a configuration called `treatWhitespaceAsNull` which, when set, prevents the driver from coercing whitespace-only values like `' '` to `null` and removing them from the entity.

Also added tests to verify both values for this configuration work as intended.

Open to suggestions on naming, the existing name is definitely verbose and might not be clear.