### PR TITLE
Allow nested attr paths (dot notation) for exists conditions

### DIFF
--- a/src/__tests__/expressionBuilder.unit.test.ts
+++ b/src/__tests__/expressionBuilder.unit.test.ts
@@ -284,10 +284,22 @@ describe('expressionBuilder', () => {
     expect(result.names).toEqual({ '#attr1': 'a' })
   })
 
+  it(`generates an 'exists' clause for a nested attribute`, () => {
+    let result = expressionBuilder({ attr: 'a.b.c', exists: true }, TestTable, 'TestEntity')
+    expect(result.expression).toBe('attribute_exists(#attr1_0.#attr1_1.#attr1_2)')
+    expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
+  })
+
   it(`generates a 'not exists' clause`, () => {
     let result = expressionBuilder({ attr: 'a', exists: false }, TestTable, 'TestEntity')
     expect(result.expression).toBe('attribute_not_exists(#attr1)')
     expect(result.names).toEqual({ '#attr1': 'a' })
+  })
+
+  it(`generates an 'not exists' clause for a nested attribute`, () => {
+    let result = expressionBuilder({ attr: 'a.b.c', exists: false }, TestTable, 'TestEntity')
+    expect(result.expression).toBe('attribute_not_exists(#attr1_0.#attr1_1.#attr1_2)')
+    expect(result.names).toEqual({ '#attr1_0': 'a', '#attr1_1': 'b', '#attr1_2': 'c' })
   })
 
   it(`generates a 'contains' clause`, () => {
@@ -379,8 +391,8 @@ describe('expressionBuilder', () => {
   it("doesn't mutate input expression", () => {
     let expObj = { attr: 'a', eq: 'b' }
     let expArr = [{ attr: 'a', eq: 'b' }]
-    expressionBuilder(expObj,TestTable,'TestEntity')
-    expressionBuilder(expArr,TestTable,'TestEntity')
+    expressionBuilder(expObj, TestTable, 'TestEntity')
+    expressionBuilder(expArr, TestTable, 'TestEntity')
     expect(expObj).toEqual({ attr: 'a', eq: 'b' })
     expect(expArr).toEqual([{ attr: 'a', eq: 'b' }])
   })


### PR DESCRIPTION
Fixes #214 by allowing nested `attr` paths (dot notation) for `exists` conditions.

e.g. currently this:

```js
{
  conditions: {
    attr: 'a.b.c',
    exists: true
  }
}
```

Generates this (which doesn't work):

```js
{
  ExpressionAttributeNames: {
    '#attr1': 'a.b.c'
  },
  ConditionExpression: 'attribute_exists(#attr_1)'
}
```

With this PR, it will instead generate this (which does work):

```js
{
  ExpressionAttributeNames: {
    '#attr1_0': 'a',
    '#attr1_1': 'b',
    '#attr1_2': 'c'
  },
  ConditionExpression: 'attribute_exists(#attr_1_0.#attr_1_1.#attr_1_2)'
}
```

The [AWS docs](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html) suggest that `attribute_exists(a.b.c)` should work but it doesn't, at least not via the JS SDK. I found out about the above syntax and workaround on Stack Overflow!

Although I only need this fixed for the `exists` conditions, for completeness it looks like I probably should implement this for the `between`, `in`, `begins_with`, `contains`, `attribute_type` and `size` conditions/operators as well.

Keen to hear thoughts!

Just to add - I considered using arrays for nested `attr` paths, e.g.

```js
{
  conditions: {
    attr: ['a', 'b', 'c'],
    exists: true
  }
}
```

As technically, you could have a valid (non-map) attribute key that is `'a.b.c'` and want to check if that exists.

However, I don't *think* many people use that syntax, and it seems dot notation is assumed as the convention for nested attributes in [`checkAttribute()`](https://github.com/jeremydaly/dynamodb-toolbox/blob/74d179af95bf110c450aebeaf9c5a55f4f46a063/src/lib/checkAttribute.ts#L9-L13), and I didn't think it made sense to introduce a different convention here.