### PR TITLE
fix: corrected "object but not array"-checks

### DIFF
--- a/src/classes/Entity/Entity.ts
+++ b/src/classes/Entity/Entity.ts
@@ -121,7 +121,7 @@ class Entity<
     >
   ) {
     // Sanity check the entity object
-    if (typeof entity !== 'object' || Array.isArray(entity)) {
+    if (entity?.constructor !== Object) {
       error('Please provide a valid entity definition')
     }
 
@@ -926,10 +926,10 @@ class Entity<
     if (!Array.isArray(DELETE)) error('DELETE must be an array')
 
     // Validate attribute names and values
-    if (typeof ExpressionAttributeNames !== 'object' || Array.isArray(ExpressionAttributeNames)) {
+    if (ExpressionAttributeNames?.constructor !== Object) {
       error('ExpressionAttributeNames must be an object')
     }
-    if (typeof ExpressionAttributeValues !== 'object' || Array.isArray(ExpressionAttributeValues)) {
+    if (ExpressionAttributeValues?.constructor !== Object) {
       error('ExpressionAttributeValues must be an object')
     }
     // if (ConditionExpression && typeof ConditionExpression !== 'string')
@@ -1136,8 +1136,7 @@ class Entity<
           // if a list and updating by index
         } else if (
           mapping.type === 'list' &&
-          !Array.isArray(data[field]) &&
-          typeof data[field] === 'object'
+          data[field]?.constructor === Object
         ) {
           Object.keys(data[field]).forEach(i => {
             if (String(parseInt(i)) !== i) {

--- a/src/classes/Table/Table.ts
+++ b/src/classes/Table/Table.ts
@@ -1070,8 +1070,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
         item.Table &&
         item.Table.Table &&
         item.Key &&
-        typeof item.Key === 'object' &&
-        !Array.isArray(item.Key)
+        item.Key?.constructor === Object
       ) {
         // Set the table
         const table = item.Table.name
@@ -1097,7 +1096,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       // If true, add to all table mappings
       if (consistent === true) {
         for (const tbl in RequestItems) RequestItems[tbl].ConsistentRead = true
-      } else if (typeof consistent === 'object' && !Array.isArray(consistent)) {
+      } else if (consistent?.constructor === Object) {
         for (const tbl in consistent as Object) {
           const tbl_name = TableAliases[tbl] || tbl
           if (RequestItems[tbl_name]) {

--- a/src/lib/parseCompositeKey.ts
+++ b/src/lib/parseCompositeKey.ts
@@ -35,7 +35,7 @@ const parseCompositeKey = <
       ? { type: 'string' }
       : ['string', 'number', 'boolean'].includes(config[2].toString())
       ? { type: config[2] }
-      : typeof config[2] === 'object' && !Array.isArray(config[2])
+      : config[2]?.constructor === Object
       ? config[2]
       : error(
           `'${field}' type must be 'string', 'number', 'boolean' or a configuration object`

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -115,7 +115,7 @@ export function parseEntity<
 
   // Sanity check the attributes
   attributes =
-    typeof attributes === 'object' && !Array.isArray(attributes)
+    attributes?.constructor === Object
       ? attributes
       : error(`Please provide a valid 'attributes' object`)
 

--- a/src/lib/parseTable.ts
+++ b/src/lib/parseTable.ts
@@ -79,7 +79,7 @@ export const parseTable = <
 
   // Parse table attributes
   attributes =
-    hasValue(attributes) && typeof attributes === 'object' && !Array.isArray(attributes)
+    hasValue(attributes) && attributes?.constructor === Object
       ? attributes
       : attributes
       ? error(`Please provide a valid 'attributes' object`)
@@ -90,7 +90,7 @@ export const parseTable = <
 
   // Parse indexes (optional)
   indexes =
-    hasValue(indexes) && typeof indexes === 'object' && !Array.isArray(indexes)
+    hasValue(indexes) && indexes?.constructor === Object
       ? // 🔨 TOIMPROVE: Allow numbers & symbols in parseIndexes ?
         parseIndexes(indexes, partitionKey as string)
       : indexes

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -42,7 +42,7 @@ export default (DocumentClient: DocumentClient) => (mapping: any, field: any, va
             .map(x => x.trim())
         : error(`'${field}' must be a list (array)`)
     case 'map':
-      return typeof value === 'object' && !Array.isArray(value)
+      return value?.constructor === Object
         ? value
         : error(`'${field}' must be a map (object)`)
     case 'set':


### PR DESCRIPTION
This was a problem because `typeof null === 'object'`. In particular this was causing issues with `default: null` on list fields.

Reference: https://stackoverflow.com/questions/8834126/how-to-efficiently-check-if-variable-is-array-or-object-in-nodejs-v8