### PR TITLE
Use strings instead of symbols for required options

### DIFF
--- a/src/v1/item/typers/any/interface.ts
+++ b/src/v1/item/typers/any/interface.ts
@@ -29,10 +29,10 @@ export interface Any<
   _type: 'any'
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    *
    * @param nextRequired RequiredOption
    */

--- a/src/v1/item/typers/any/options.ts
+++ b/src/v1/item/typers/any/options.ts
@@ -1,4 +1,4 @@
-import { RequiredOption, Never } from '../constants/requiredOptions'
+import type { RequiredOption, Never } from '../constants/requiredOptions'
 
 import type { AnyDefaultValue } from './types'
 
@@ -14,10 +14,10 @@ export interface AnyOptions<
 > {
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    */
   required: R
   /**
@@ -39,7 +39,7 @@ export interface AnyOptions<
 }
 
 export const anyDefaultOptions: AnyOptions<Never, false, false, undefined, undefined> = {
-  required: Never,
+  required: 'never',
   hidden: false,
   key: false,
   savedAs: undefined,

--- a/src/v1/item/typers/any/typer.ts
+++ b/src/v1/item/typers/any/typer.ts
@@ -1,6 +1,6 @@
 import type { O } from 'ts-toolbelt'
 
-import { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
+import type { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
 
 import type { AnyDefaultValue } from './types'
 import type { Any } from './interface'
@@ -47,7 +47,7 @@ export const any: AnyTyper = <
     _savedAs,
     _default,
     required: <$R extends RequiredOption = AtLeastOnce>(
-      nextRequired: $R = AtLeastOnce as unknown as $R
+      nextRequired: $R = ('atLeastOnce' as unknown) as $R
     ) => any({ ...appliedOptions, required: nextRequired }),
     hidden: () => any({ ...appliedOptions, hidden: true }),
     key: () => any({ ...appliedOptions, key: true }),

--- a/src/v1/item/typers/any/typer.unit.test.ts
+++ b/src/v1/item/typers/any/typer.unit.test.ts
@@ -23,7 +23,7 @@ describe('any', () => {
 
     expect(anyInstance).toMatchObject({
       _type: 'any',
-      _required: Never,
+      _required: 'never',
       _hidden: false,
       _savedAs: undefined,
       _key: false,
@@ -32,10 +32,10 @@ describe('any', () => {
   })
 
   it('returns required any (option)', () => {
-    const anyAtLeastOnce = any({ required: AtLeastOnce })
-    const anyOnlyOnce = any({ required: OnlyOnce })
-    const anyAlways = any({ required: Always })
-    const anyNever = any({ required: Never })
+    const anyAtLeastOnce = any({ required: 'atLeastOnce' })
+    const anyOnlyOnce = any({ required: 'onlyOnce' })
+    const anyAlways = any({ required: 'always' })
+    const anyNever = any({ required: 'never' })
 
     const assertAtLeastOnce: A.Contains<typeof anyAtLeastOnce, { _required: AtLeastOnce }> = 1
     assertAtLeastOnce
@@ -46,17 +46,17 @@ describe('any', () => {
     const assertNever: A.Contains<typeof anyNever, { _required: Never }> = 1
     assertNever
 
-    expect(anyAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(anyOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(anyAlways).toMatchObject({ _required: Always })
-    expect(anyNever).toMatchObject({ _required: Never })
+    expect(anyAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(anyOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(anyAlways).toMatchObject({ _required: 'always' })
+    expect(anyNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns required any (method)', () => {
     const anyAtLeastOnce = any().required()
-    const anyOnlyOnce = any().required(OnlyOnce)
-    const anyAlways = any().required(Always)
-    const anyNever = any().required(Never)
+    const anyOnlyOnce = any().required('onlyOnce')
+    const anyAlways = any().required('always')
+    const anyNever = any().required('never')
 
     const assertAtLeastOnce: A.Contains<typeof anyAtLeastOnce, { _required: AtLeastOnce }> = 1
     assertAtLeastOnce
@@ -67,10 +67,10 @@ describe('any', () => {
     const assertNever: A.Contains<typeof anyNever, { _required: Never }> = 1
     assertNever
 
-    expect(anyAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(anyOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(anyAlways).toMatchObject({ _required: Always })
-    expect(anyNever).toMatchObject({ _required: Never })
+    expect(anyAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(anyOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(anyAlways).toMatchObject({ _required: 'always' })
+    expect(anyNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns hidden any (option)', () => {

--- a/src/v1/item/typers/constants/requiredOptions.ts
+++ b/src/v1/item/typers/constants/requiredOptions.ts
@@ -1,38 +1,22 @@
 /**
  * Tag for optional properties
  */
-export const Never = Symbol('Tag for optional properties')
-/**
- * Tag for optional properties
- */
-export type Never = typeof Never
+export type Never = 'never'
 
 /**
  * Tag for required at least once properties
  */
-export const AtLeastOnce = Symbol('Tag for required at least once properties')
-/**
- * Tag for required at least once properties
- */
-export type AtLeastOnce = typeof AtLeastOnce
+export type AtLeastOnce = 'atLeastOnce'
 
 /**
  * Tag for required only once properties
  */
-export const OnlyOnce = Symbol('Tag for required only once properties')
-/**
- * Tag for required only once properties
- */
-export type OnlyOnce = typeof OnlyOnce
+export type OnlyOnce = 'onlyOnce'
 
 /**
  * Tag for always required properties
  */
-export const Always = Symbol('Tag for always required properties')
-/**
- * Tag for always required properties
- */
-export type Always = typeof Always
+export type Always = 'always'
 
 /**
  * Available options for properties required option

--- a/src/v1/item/typers/leaf/interface.ts
+++ b/src/v1/item/typers/leaf/interface.ts
@@ -36,10 +36,10 @@ export type Leaf<
   _resolved?: E extends ResolveLeafType<T>[] ? E[number] : ResolveLeafType<T>
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    *
    * @param nextRequired RequiredOption
    */

--- a/src/v1/item/typers/leaf/options.ts
+++ b/src/v1/item/typers/leaf/options.ts
@@ -1,4 +1,4 @@
-import { RequiredOption, Never } from '../constants/requiredOptions'
+import type { RequiredOption, Never } from '../constants/requiredOptions'
 
 import type { LeafType, EnumValues, LeafDefaultValue } from './types'
 
@@ -16,10 +16,10 @@ export interface LeafOptions<
 > {
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    */
   required: R
   /**
@@ -50,7 +50,7 @@ export const leafDefaultOptions: LeafOptions<
   undefined,
   undefined
 > = {
-  required: Never,
+  required: 'never',
   hidden: false,
   key: false,
   savedAs: undefined,

--- a/src/v1/item/typers/leaf/typer.ts
+++ b/src/v1/item/typers/leaf/typer.ts
@@ -1,6 +1,6 @@
 import type { O } from 'ts-toolbelt'
 
-import { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
+import type { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
 
 import type { Leaf } from './interface'
 import { LeafOptions, leafDefaultOptions } from './options'
@@ -40,7 +40,7 @@ const leaf = <
     _savedAs,
     _default,
     _enum,
-    required: <$R extends RequiredOption = AtLeastOnce>(nextRequired = AtLeastOnce as $R) =>
+    required: <$R extends RequiredOption = AtLeastOnce>(nextRequired = 'atLeastOnce' as $R) =>
       leaf({ ...options, required: nextRequired }),
     hidden: () => leaf({ ...options, hidden: true }),
     key: () => leaf({ ...options, key: true }),

--- a/src/v1/item/typers/leaf/typer.unit.test.ts
+++ b/src/v1/item/typers/leaf/typer.unit.test.ts
@@ -31,7 +31,7 @@ describe('leaf', () => {
 
       expect(str).toMatchObject({
         _type: 'string',
-        _required: Never,
+        _required: 'never',
         _hidden: false,
         _savedAs: undefined,
         _key: false,
@@ -40,10 +40,10 @@ describe('leaf', () => {
     })
 
     it('returns required string (option)', () => {
-      const strAtLeastOnce = string({ required: AtLeastOnce })
-      const strOnlyOnce = string({ required: OnlyOnce })
-      const strAlways = string({ required: Always })
-      const strNever = string({ required: Never })
+      const strAtLeastOnce = string({ required: 'atLeastOnce' })
+      const strOnlyOnce = string({ required: 'onlyOnce' })
+      const strAlways = string({ required: 'always' })
+      const strNever = string({ required: 'never' })
 
       const assertAtLeastOnce: A.Contains<typeof strAtLeastOnce, { _required: AtLeastOnce }> = 1
       assertAtLeastOnce
@@ -54,17 +54,17 @@ describe('leaf', () => {
       const assertNever: A.Contains<typeof strNever, { _required: Never }> = 1
       assertNever
 
-      expect(strAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-      expect(strOnlyOnce).toMatchObject({ _required: OnlyOnce })
-      expect(strAlways).toMatchObject({ _required: Always })
-      expect(strNever).toMatchObject({ _required: Never })
+      expect(strAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+      expect(strOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+      expect(strAlways).toMatchObject({ _required: 'always' })
+      expect(strNever).toMatchObject({ _required: 'never' })
     })
 
     it('returns required string (method)', () => {
       const strAtLeastOnce = string().required()
-      const strOnlyOnce = string().required(OnlyOnce)
-      const strAlways = string().required(Always)
-      const strNever = string().required(Never)
+      const strOnlyOnce = string().required('onlyOnce')
+      const strAlways = string().required('always')
+      const strNever = string().required('never')
 
       const assertAtLeastOnce: A.Contains<typeof strAtLeastOnce, { _required: AtLeastOnce }> = 1
       assertAtLeastOnce
@@ -75,10 +75,10 @@ describe('leaf', () => {
       const assertNever: A.Contains<typeof strNever, { _required: Never }> = 1
       assertNever
 
-      expect(strAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-      expect(strOnlyOnce).toMatchObject({ _required: OnlyOnce })
-      expect(strAlways).toMatchObject({ _required: Always })
-      expect(strNever).toMatchObject({ _required: Never })
+      expect(strAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+      expect(strOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+      expect(strAlways).toMatchObject({ _required: 'always' })
+      expect(strNever).toMatchObject({ _required: 'never' })
     })
 
     it('returns hidden string (option)', () => {

--- a/src/v1/item/typers/list/interface.ts
+++ b/src/v1/item/typers/list/interface.ts
@@ -31,10 +31,10 @@ export interface List<
   _elements: E
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    *
    * @param nextRequired RequiredOption
    */

--- a/src/v1/item/typers/list/options.ts
+++ b/src/v1/item/typers/list/options.ts
@@ -12,10 +12,10 @@ export interface ListOptions<
 > {
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    */
   required: R
   /**
@@ -37,7 +37,7 @@ export interface ListOptions<
 }
 
 export const listDefaultOptions: ListOptions<Never, false, false, undefined, undefined> = {
-  required: Never,
+  required: 'never',
   hidden: false,
   key: false,
   savedAs: undefined,

--- a/src/v1/item/typers/list/typer.ts
+++ b/src/v1/item/typers/list/typer.ts
@@ -58,7 +58,7 @@ export const list: ListTyper = <
     _key,
     _savedAs,
     _default,
-    required: <$R extends RequiredOption = AtLeastOnce>(nextRequired: $R = AtLeastOnce as $R) =>
+    required: <$R extends RequiredOption = AtLeastOnce>(nextRequired: $R = 'atLeastOnce' as $R) =>
       list(elements, { ...appliedOptions, required: nextRequired }),
     hidden: () => list(elements, { ...appliedOptions, hidden: true }),
     key: () => list(elements, { ...appliedOptions, key: true }),

--- a/src/v1/item/typers/list/typer.unit.test.ts
+++ b/src/v1/item/typers/list/typer.unit.test.ts
@@ -95,7 +95,7 @@ describe('list', () => {
     expect(lst).toMatchObject({
       _type: 'list',
       _elements: str,
-      _required: Never,
+      _required: 'never',
       _key: false,
       _savedAs: undefined,
       _hidden: false
@@ -103,10 +103,10 @@ describe('list', () => {
   })
 
   it('returns required list (option)', () => {
-    const lstAtLeastOnce = list(str, { required: AtLeastOnce })
-    const lstOnlyOnce = list(str, { required: OnlyOnce })
-    const lstAlways = list(str, { required: Always })
-    const lstNever = list(str, { required: Never })
+    const lstAtLeastOnce = list(str, { required: 'atLeastOnce' })
+    const lstOnlyOnce = list(str, { required: 'onlyOnce' })
+    const lstAlways = list(str, { required: 'always' })
+    const lstNever = list(str, { required: 'never' })
 
     const assertAtLeastOnce: A.Contains<typeof lstAtLeastOnce, { _required: AtLeastOnce }> = 1
     assertAtLeastOnce
@@ -117,17 +117,17 @@ describe('list', () => {
     const assertNever: A.Contains<typeof lstNever, { _required: Never }> = 1
     assertNever
 
-    expect(lstAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(lstOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(lstAlways).toMatchObject({ _required: Always })
-    expect(lstNever).toMatchObject({ _required: Never })
+    expect(lstAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(lstOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(lstAlways).toMatchObject({ _required: 'always' })
+    expect(lstNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns required list (method)', () => {
     const lstAtLeastOnce = list(str).required()
-    const lstOnlyOnce = list(str).required(OnlyOnce)
-    const lstAlways = list(str).required(Always)
-    const lstNever = list(str).required(Never)
+    const lstOnlyOnce = list(str).required('onlyOnce')
+    const lstAlways = list(str).required('always')
+    const lstNever = list(str).required('never')
 
     const assertAtLeastOnce: A.Contains<typeof lstAtLeastOnce, { _required: AtLeastOnce }> = 1
     assertAtLeastOnce
@@ -138,10 +138,10 @@ describe('list', () => {
     const assertNever: A.Contains<typeof lstNever, { _required: Never }> = 1
     assertNever
 
-    expect(lstAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(lstOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(lstAlways).toMatchObject({ _required: Always })
-    expect(lstNever).toMatchObject({ _required: Never })
+    expect(lstAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(lstOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(lstAlways).toMatchObject({ _required: 'always' })
+    expect(lstNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns hidden list (option)', () => {
@@ -246,13 +246,13 @@ describe('list', () => {
       _elements: {
         _type: 'list',
         _elements: str,
-        _required: AtLeastOnce,
+        _required: 'atLeastOnce',
         _hidden: false,
         _key: false,
         _savedAs: undefined,
         _default: undefined
       },
-      _required: Never,
+      _required: 'never',
       _hidden: false,
       _key: false,
       _savedAs: undefined,

--- a/src/v1/item/typers/list/validate.ts
+++ b/src/v1/item/typers/list/validate.ts
@@ -1,4 +1,3 @@
-import { AtLeastOnce } from '../constants/requiredOptions'
 import { errorMessagePathSuffix, validateProperty } from '../validate'
 
 import type { List } from './interface'
@@ -64,7 +63,7 @@ export const validateList = <L extends List>(
     _default: elementsDefault
   } = elements
 
-  if (elementsRequired !== AtLeastOnce) {
+  if (elementsRequired !== 'atLeastOnce') {
     throw new OptionalListElementsError({ path })
   }
 

--- a/src/v1/item/typers/map/interface.ts
+++ b/src/v1/item/typers/map/interface.ts
@@ -35,10 +35,10 @@ export interface Mapped<
   _properties: P
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    *
    * @param nextRequired RequiredOption
    */

--- a/src/v1/item/typers/map/options.ts
+++ b/src/v1/item/typers/map/options.ts
@@ -13,10 +13,10 @@ export interface MappedOptions<
 > {
   /**
    * Tag a property as required. Possible values are:
-   * - `AtLeastOnce` _(default)_: Required in PUTs, optional in UPDATEs
-   * - `Never`: Optional in PUTs and UPDATEs
-   * - `Always`: Required in PUTs and UPDATEs
-   * - `OnlyOnce` (default): Required in PUTs, denied in UPDATEs
+   * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
+   * - `"never"`: Optional in PUTs and UPDATEs
+   * - `"always"`: Required in PUTs and UPDATEs
+   * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    */
   required: R
   /**
@@ -41,12 +41,18 @@ export interface MappedOptions<
   default: D
 }
 
-export const mappedDefaultOptions: MappedOptions<Never, false, false, false, undefined, undefined> =
-  {
-    required: Never,
-    hidden: false,
-    key: false,
-    open: false,
-    savedAs: undefined,
-    default: undefined
-  }
+export const mappedDefaultOptions: MappedOptions<
+  Never,
+  false,
+  false,
+  false,
+  undefined,
+  undefined
+> = {
+  required: 'never',
+  hidden: false,
+  key: false,
+  open: false,
+  savedAs: undefined,
+  default: undefined
+}

--- a/src/v1/item/typers/map/typer.ts
+++ b/src/v1/item/typers/map/typer.ts
@@ -57,7 +57,7 @@ export const map: MappedTyper = <
     _savedAs,
     _default,
     required: <$R extends RequiredOption = AtLeastOnce>(
-      nextRequired: $R = AtLeastOnce as unknown as $R
+      nextRequired: $R = ('atLeastOnce' as unknown) as $R
     ) => map(properties, { ...appliedOptions, required: nextRequired }),
     hidden: () => map(properties, { ...appliedOptions, hidden: true }),
     key: () => map(properties, { ...appliedOptions, key: true }),

--- a/src/v1/item/typers/map/typer.unit.test.ts
+++ b/src/v1/item/typers/map/typer.unit.test.ts
@@ -30,7 +30,7 @@ describe('map', () => {
     expect(mapped).toMatchObject({
       _type: 'map',
       _properties: { str },
-      _required: Never,
+      _required: 'never',
       _key: false,
       _savedAs: undefined,
       _hidden: false
@@ -38,10 +38,10 @@ describe('map', () => {
   })
 
   it('returns required map (option)', () => {
-    const mappedAtLeastOnce = map({ str }, { required: AtLeastOnce })
-    const mappedOnlyOnce = map({ str }, { required: OnlyOnce })
-    const mappedAlways = map({ str }, { required: Always })
-    const mappedNever = map({ str }, { required: Never })
+    const mappedAtLeastOnce = map({ str }, { required: 'atLeastOnce' })
+    const mappedOnlyOnce = map({ str }, { required: 'onlyOnce' })
+    const mappedAlways = map({ str }, { required: 'always' })
+    const mappedNever = map({ str }, { required: 'never' })
 
     const assertMappedAtLeastOnce: A.Contains<
       typeof mappedAtLeastOnce,
@@ -55,17 +55,17 @@ describe('map', () => {
     const assertMappedNever: A.Contains<typeof mappedNever, { _required: Never }> = 1
     assertMappedNever
 
-    expect(mappedAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(mappedOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(mappedAlways).toMatchObject({ _required: Always })
-    expect(mappedNever).toMatchObject({ _required: Never })
+    expect(mappedAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(mappedOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(mappedAlways).toMatchObject({ _required: 'always' })
+    expect(mappedNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns required map (method)', () => {
     const mappedAtLeastOnce = map({ str }).required()
-    const mappedOnlyOnce = map({ str }).required(OnlyOnce)
-    const mappedAlways = map({ str }).required(Always)
-    const mappedNever = map({ str }).required(Never)
+    const mappedOnlyOnce = map({ str }).required('onlyOnce')
+    const mappedAlways = map({ str }).required('always')
+    const mappedNever = map({ str }).required('never')
 
     const assertMappedAtLeastOnce: A.Contains<
       typeof mappedAtLeastOnce,
@@ -79,10 +79,10 @@ describe('map', () => {
     const assertMappedNever: A.Contains<typeof mappedNever, { _required: Never }> = 1
     assertMappedNever
 
-    expect(mappedAtLeastOnce).toMatchObject({ _required: AtLeastOnce })
-    expect(mappedOnlyOnce).toMatchObject({ _required: OnlyOnce })
-    expect(mappedAlways).toMatchObject({ _required: Always })
-    expect(mappedNever).toMatchObject({ _required: Never })
+    expect(mappedAtLeastOnce).toMatchObject({ _required: 'atLeastOnce' })
+    expect(mappedOnlyOnce).toMatchObject({ _required: 'onlyOnce' })
+    expect(mappedAlways).toMatchObject({ _required: 'always' })
+    expect(mappedNever).toMatchObject({ _required: 'never' })
   })
 
   it('returns hidden map (option)', () => {
@@ -233,21 +233,21 @@ describe('map', () => {
               _properties: {
                 str
               },
-              _required: Never,
+              _required: 'never',
               _hidden: true,
               _key: false,
               _savedAs: undefined,
               _default: undefined
             }
           },
-          _required: AtLeastOnce,
+          _required: 'atLeastOnce',
           _hidden: false,
           _key: false,
           _savedAs: undefined,
           _default: undefined
         }
       },
-      _required: Never,
+      _required: 'never',
       _hidden: false,
       _key: false,
       _savedAs: undefined,

--- a/src/v1/playground/entity.ts
+++ b/src/v1/playground/entity.ts
@@ -1,4 +1,4 @@
-import { Always, ComputedDefault, map, number, string, item } from 'v1/item'
+import { ComputedDefault, map, number, string, item } from 'v1/item'
 import { EntityV2, PutItemInput, SavedItem, FormattedItem, KeyInput, PutItem } from 'v1/entity'
 
 import { MyTable } from './table'
@@ -7,8 +7,8 @@ export const UserEntity = new EntityV2({
   name: 'User',
   table: MyTable,
   item: item({
-    userId: string().key().required(Always),
-    age: number().key().required(Always).enum(41, 42).default(42).savedAs('sk'),
+    userId: string().key().required('always'),
+    age: number().key().required('always').enum(41, 42).default(42).savedAs('sk'),
     firstName: string().required().savedAs('fn'),
     lastName: string().required().savedAs('ln'),
     parents: map({


### PR DESCRIPTION
Follows a feedback from @jeremydaly to use strings instead of symbols for more simplicity (avoir importing symbols from `"dynamodb-toolbox"`).