### PR TITLE
Statically type the return types for `batchGet` and `batchWrite`.

### DIFF
--- a/src/classes/Table/types.ts
+++ b/src/classes/Table/types.ts
@@ -106,7 +106,11 @@ export interface BatchGetOptions {
 }
 
 export interface BatchGetParamsMeta {
-  payload: any
+  payload: {
+    RequestItems: DocumentClient.BatchGetRequestMap;
+} & {
+    ReturnConsumedCapacity: string;
+} & Partial<DocumentClient.BatchGetItemInput>
   Tables: { [key: string]: TableDef }
   EntityProjections: { [key: string]: any }
   TableProjections: { [key: string]: string[] }


### PR DESCRIPTION
This PR reduces the number of `any` in the batch signatures. The ultimate goal was to statically type the return types for `batchGet` and `batchWrite`.