### PR TITLE
chore(deps): upgrade ts-toolbelt to 9.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.5.0-beta.0",
       "license": "MIT",
       "dependencies": {
-        "ts-toolbelt": "^6.15.5"
+        "ts-toolbelt": "^9.6.0"
       },
       "devDependencies": {
         "@types/jest": "^26.0.19",
@@ -7096,9 +7096,9 @@
       }
     },
     "node_modules/ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "node_modules/tsd": {
       "version": "0.23.0",
@@ -8721,7 +8721,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -11152,7 +11153,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.0.6",
@@ -13058,9 +13060,9 @@
       }
     },
     "ts-toolbelt": {
-      "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
-      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "tsd": {
       "version": "0.23.0",
@@ -13325,7 +13327,8 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "ts-toolbelt": "^6.15.5"
+    "ts-toolbelt": "^9.6.0"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -503,15 +503,8 @@ describe('put', () => {
   })
 
   it('sets conditions', () => {
-    let {
-      TableName,
-      ExpressionAttributeNames,
-      ExpressionAttributeValues,
-      ConditionExpression
-    } = TestEntity.putParams(
-      { email: 'x', sort: 'y' },
-      { conditions: { attr: 'email', gt: 'test' } }
-    )
+    let { TableName, ExpressionAttributeNames, ExpressionAttributeValues, ConditionExpression } =
+      TestEntity.putParams({ email: 'x', sort: 'y' }, { conditions: { attr: 'email', gt: 'test' } })
     expect(TableName).toBe('test-table')
     expect(ExpressionAttributeNames).toEqual({ '#attr1': 'pk' })
     expect(ExpressionAttributeValues).toEqual({ ':attr1': 'test' })

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -72,7 +72,7 @@ type ExpectedWriteOpts<
   conditions: ConditionsOrFilters<Attributes>
   metrics: string
   include: string[]
-  returnValues: ReturnValues,
+  returnValues: ReturnValues
   strictSchemaCheck: boolean
 }>
 
@@ -276,7 +276,7 @@ describe('Entity', () => {
       it('nominal case', () => {
         ent.getParams({ pk })
         const getPromise = () => ent.get({ pk })
-        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
@@ -298,7 +298,7 @@ describe('Entity', () => {
       it('no auto-execution', () => {
         const item = { pk }
         const getPromise = () => entNoExecute.get(item)
-        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type GetParams = A.Await<F.Return<typeof getPromise>>
         type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
         const testGetParams: TestGetParams = 1
         testGetParams
@@ -307,7 +307,7 @@ describe('Entity', () => {
       it('force execution', () => {
         const item = { pk }
         const getPromise = () => entNoExecute.get(item, { execute: true })
-        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
@@ -316,7 +316,7 @@ describe('Entity', () => {
       it('force no execution', () => {
         const item = { pk }
         const getPromise = () => ent.get(item, { execute: false })
-        type GetParams = C.PromiseOf<F.Return<typeof getPromise>>
+        type GetParams = A.Await<F.Return<typeof getPromise>>
         type TestGetParams = A.Equals<GetParams, DocumentClientType.GetItemInput>
         const testGetParams: TestGetParams = 1
         testGetParams
@@ -325,7 +325,7 @@ describe('Entity', () => {
       it('no auto-parsing', () => {
         const item = { pk }
         const getPromise = () => entNoParse.get(item)
-        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type GetRawResponse = A.Await<F.Return<typeof getPromise>>
         type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
         const testGetRawResponse: TestGetRawResponse = 1
         testGetRawResponse
@@ -334,7 +334,7 @@ describe('Entity', () => {
       it('force parsing', () => {
         const item = { pk }
         const getPromise = () => entNoParse.get(item, { parse: true })
-        type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
         type TestGetItem = A.Equals<GetItem, ExpectedItem | undefined>
         const testGetItem: TestGetItem = 1
         testGetItem
@@ -343,7 +343,7 @@ describe('Entity', () => {
       it('force no parsing', () => {
         const item = { pk }
         const getPromise = () => ent.get(item, { parse: false })
-        type GetRawResponse = C.PromiseOf<F.Return<typeof getPromise>>
+        type GetRawResponse = A.Await<F.Return<typeof getPromise>>
         type TestGetRawResponse = A.Equals<GetRawResponse, DocumentClientType.GetItemOutput>
         const testGetRawResponse: TestGetRawResponse = 1
         testGetRawResponse
@@ -352,7 +352,7 @@ describe('Entity', () => {
       it('contains no timestamp', () => {
         const item = { pk }
         const getPromise = () => entNoTimestamps.get(item)
-        type GetResponse = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+        type GetResponse = A.Await<F.Return<typeof getPromise>>['Item']
         type TestGetResponse = A.Equals<
           GetResponse,
           Omit<ExpectedItem, 'created' | 'modified'> | undefined
@@ -373,7 +373,7 @@ describe('Entity', () => {
       it('with filters', () => {
         ent.getParams({ pk }, { attributes: ['pk'] })
         const filteredGetPromise = () => ent.get({ pk }, { attributes: ['pk'] })
-        type FilteredGetItem = C.PromiseOf<F.Return<typeof filteredGetPromise>>['Item']
+        type FilteredGetItem = A.Await<F.Return<typeof filteredGetPromise>>['Item']
         type TestFilteredGetItem = A.Equals<FilteredGetItem, Pick<ExpectedItem, 'pk'> | undefined>
         const testFilteredGetItem: TestFilteredGetItem = 1
         testFilteredGetItem
@@ -386,13 +386,13 @@ describe('Entity', () => {
     describe('delete method', () => {
       it('nominal case', () => {
         const deletePromise1 = () => ent.delete({ pk }, { returnValues: 'ALL_OLD' })
-        type DeleteItem1 = C.PromiseOf<F.Return<typeof deletePromise1>>['Attributes']
+        type DeleteItem1 = A.Await<F.Return<typeof deletePromise1>>['Attributes']
         type TestDeleteItem1 = A.Equals<DeleteItem1, ExpectedItem | undefined>
         const testDeleteItem1: TestDeleteItem1 = 1
         testDeleteItem1
 
         const deletePromise2 = () => ent.delete(pkMaps, { returnValues: 'ALL_OLD' })
-        type DeleteItem2 = C.PromiseOf<F.Return<typeof deletePromise2>>['Attributes']
+        type DeleteItem2 = A.Await<F.Return<typeof deletePromise2>>['Attributes']
         type TestDeleteItem2 = A.Equals<DeleteItem2, ExpectedItem | undefined>
         const testDeleteItem2: TestDeleteItem2 = 1
         testDeleteItem2
@@ -400,7 +400,10 @@ describe('Entity', () => {
         type DeleteItemOptions = DeleteOptions<typeof ent>
         type TestDeleteItemOptions = A.Equals<
           DeleteItemOptions,
-          Omit<ExpectedWriteOpts<keyof ExpectedItem | 'hidden', 'NONE' | 'ALL_OLD'>, 'strictSchemaCheck'>
+          Omit<
+            ExpectedWriteOpts<keyof ExpectedItem | 'hidden', 'NONE' | 'ALL_OLD'>,
+            'strictSchemaCheck'
+          >
         >
         const testDeleteItemOptions: TestDeleteItemOptions = 1
         testDeleteItemOptions
@@ -409,7 +412,7 @@ describe('Entity', () => {
       it('no auto-execution', () => {
         const item = { pk }
         const deletePromise = () => entNoExecute.delete(item)
-        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type DeleteParams = A.Await<F.Return<typeof deletePromise>>
         type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
         const testDeleteParams: TestDeleteParams = 1
         testDeleteParams
@@ -419,7 +422,7 @@ describe('Entity', () => {
         const item = { pk }
         const deletePromise = () =>
           entNoExecute.delete(item, { execute: true, returnValues: 'ALL_OLD' })
-        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
         type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
         const testDeleteItem: TestDeleteItem = 1
         testDeleteItem
@@ -428,7 +431,7 @@ describe('Entity', () => {
       it('force no execution', () => {
         const item = { pk }
         const deletePromise = () => ent.delete(item, { execute: false })
-        type DeleteParams = C.PromiseOf<F.Return<typeof deletePromise>>
+        type DeleteParams = A.Await<F.Return<typeof deletePromise>>
         type TestDeleteParams = A.Equals<DeleteParams, DocumentClientType.DeleteItemInput>
         const testDeleteParams: TestDeleteParams = 1
         testDeleteParams
@@ -437,7 +440,7 @@ describe('Entity', () => {
       it('no auto-parsing', () => {
         const item = { pk }
         const deletePromise = () => entNoParse.delete(item)
-        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type DeleteRawResponse = A.Await<F.Return<typeof deletePromise>>
         type TestDeleteRawResponse = A.Equals<
           DeleteRawResponse,
           DocumentClientType.DeleteItemOutput
@@ -450,7 +453,7 @@ describe('Entity', () => {
         const item = { pk }
         const deletePromise = () =>
           entNoParse.delete(item, { parse: true, returnValues: 'ALL_OLD' })
-        type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
         type TestDeleteItem = A.Equals<DeleteItem, ExpectedItem | undefined>
         const testDeleteItem: TestDeleteItem = 1
         testDeleteItem
@@ -459,7 +462,7 @@ describe('Entity', () => {
       it('force no parsing', () => {
         const item = { pk }
         const deletePromise = () => ent.update(item, { parse: false })
-        type DeleteRawResponse = C.PromiseOf<F.Return<typeof deletePromise>>
+        type DeleteRawResponse = A.Await<F.Return<typeof deletePromise>>
         type TestDeleteRawResponse = A.Equals<
           DeleteRawResponse,
           DocumentClientType.DeleteItemOutput
@@ -471,7 +474,7 @@ describe('Entity', () => {
       it('contains no timestamp', () => {
         const item = { pk }
         const deletePromise = () => entNoTimestamps.delete(item, { returnValues: 'ALL_OLD' })
-        type DeleteResponse = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+        type DeleteResponse = A.Await<F.Return<typeof deletePromise>>['Attributes']
         type TestDeleteResponse = A.Equals<
           DeleteResponse,
           Omit<ExpectedItem, 'created' | 'modified'> | undefined
@@ -510,7 +513,7 @@ describe('Entity', () => {
         const item1 = { pk, hidden: 'test' }
         ent.putParams(item1, { returnValues: 'ALL_OLD' })
         const putPromise1 = () => ent.put({ pk }, { returnValues: 'ALL_OLD' })
-        type PutItem1 = C.PromiseOf<F.Return<typeof putPromise1>>['Attributes']
+        type PutItem1 = A.Await<F.Return<typeof putPromise1>>['Attributes']
         type TestPutItem1 = A.Equals<PutItem1, ExpectedItem | undefined>
         const testPutItem1: TestPutItem1 = 1
         testPutItem1
@@ -518,7 +521,7 @@ describe('Entity', () => {
         const item2 = pkMaps
         ent.putParams(item2, { returnValues: 'ALL_OLD' })
         const putPromise2 = () => ent.put(item2, { returnValues: 'ALL_OLD' })
-        type PutItem2 = C.PromiseOf<F.Return<typeof putPromise2>>['Attributes']
+        type PutItem2 = A.Await<F.Return<typeof putPromise2>>['Attributes']
         type TestPutItem2 = A.Equals<PutItem2, ExpectedItem | undefined>
         const testPutItem2: TestPutItem2 = 1
         testPutItem2
@@ -535,7 +538,7 @@ describe('Entity', () => {
       it('no auto-execution', () => {
         const item = { pk }
         const putPromise = () => entNoExecute.put(item)
-        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type PutParams = A.Await<F.Return<typeof putPromise>>
         type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
         const testPutParams: TestPutParams = 1
         testPutParams
@@ -544,7 +547,7 @@ describe('Entity', () => {
       it('force execution', () => {
         const item = { pk }
         const putPromise = () => entNoExecute.put(item, { execute: true, returnValues: 'ALL_OLD' })
-        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type PutItem = A.Await<F.Return<typeof putPromise>>['Attributes']
         type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
         const testPutItem: TestPutItem = 1
         testPutItem
@@ -553,7 +556,7 @@ describe('Entity', () => {
       it('force no execution', () => {
         const item = { pk }
         const putPromise = () => ent.put(item, { execute: false, returnValues: 'ALL_OLD' })
-        type PutParams = C.PromiseOf<F.Return<typeof putPromise>>
+        type PutParams = A.Await<F.Return<typeof putPromise>>
         type TestPutParams = A.Equals<PutParams, DocumentClientType.PutItemInput>
         const testPutParams: TestPutParams = 1
         testPutParams
@@ -562,7 +565,7 @@ describe('Entity', () => {
       it('no auto-parsing', () => {
         const item = { pk }
         const putPromise = () => entNoParse.put(item)
-        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type PutRawResponse = A.Await<F.Return<typeof putPromise>>
         type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
         const testPutRawResponse: TestPutRawResponse = 1
         testPutRawResponse
@@ -571,7 +574,7 @@ describe('Entity', () => {
       it('force parsing', () => {
         const item = { pk }
         const putPromise = () => entNoParse.put(item, { parse: true, returnValues: 'ALL_OLD' })
-        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type PutItem = A.Await<F.Return<typeof putPromise>>['Attributes']
         type TestPutItem = A.Equals<PutItem, ExpectedItem | undefined>
         const testPutItem: TestPutItem = 1
         testPutItem
@@ -580,7 +583,7 @@ describe('Entity', () => {
       it('force no parsing', () => {
         const item = { pk }
         const putPromise = () => ent.put(item, { parse: false })
-        type PutRawResponse = C.PromiseOf<F.Return<typeof putPromise>>
+        type PutRawResponse = A.Await<F.Return<typeof putPromise>>
         type TestPutRawResponse = A.Equals<PutRawResponse, DocumentClientType.PutItemOutput>
         const testPutRawResponse: TestPutRawResponse = 1
         testPutRawResponse
@@ -589,7 +592,7 @@ describe('Entity', () => {
       it('contains no timestamp', () => {
         const item = { pk }
         const putPromise = () => entNoTimestamps.put(item, { returnValues: 'ALL_OLD' })
-        type PutResponse = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type PutResponse = A.Await<F.Return<typeof putPromise>>['Attributes']
         type TestPutResponse = A.Equals<
           PutResponse,
           Omit<ExpectedItem, 'created' | 'modified'> | undefined
@@ -625,7 +628,7 @@ describe('Entity', () => {
         const item1 = { pk, hidden: 'test' }
         ent.updateParams(item1)
         const updatePromise1 = () => ent.update(item1, { returnValues: 'ALL_OLD' })
-        type UpdateItem1 = C.PromiseOf<F.Return<typeof updatePromise1>>['Attributes']
+        type UpdateItem1 = A.Await<F.Return<typeof updatePromise1>>['Attributes']
         type TestUpdateItem1 = A.Equals<UpdateItem1, ExpectedItem | undefined>
         const testUpdateItem1: TestUpdateItem1 = 1
         testUpdateItem1
@@ -633,7 +636,7 @@ describe('Entity', () => {
         const item2 = pkMaps
         ent.updateParams(item2)
         const updatePromise2 = () => ent.update(item2, { returnValues: 'ALL_NEW' })
-        type UpdateItem2 = C.PromiseOf<F.Return<typeof updatePromise2>>['Attributes']
+        type UpdateItem2 = A.Await<F.Return<typeof updatePromise2>>['Attributes']
         type TestUpdateItem2 = A.Equals<UpdateItem2, ExpectedItem | undefined>
         const testUpdateItem2: TestUpdateItem2 = 1
         testUpdateItem2
@@ -653,7 +656,7 @@ describe('Entity', () => {
       it('no auto-execution', () => {
         const item = { pk }
         const updatePromise = () => entNoExecute.update(item)
-        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type UpdateParams = A.Await<F.Return<typeof updatePromise>>
         type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
         const testUpdateParams: TestUpdateParams = 1
         testUpdateParams
@@ -663,7 +666,7 @@ describe('Entity', () => {
         const item = { pk }
         const updatePromise = () =>
           entNoExecute.update(item, { execute: true, returnValues: 'ALL_NEW' })
-        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type UpdateItem = A.Await<F.Return<typeof updatePromise>>['Attributes']
         type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
         const testUpdateItem: TestUpdateItem = 1
         testUpdateItem
@@ -672,7 +675,7 @@ describe('Entity', () => {
       it('force no execution', () => {
         const item = { pk }
         const updatePromise = () => ent.update(item, { execute: false })
-        type UpdateParams = C.PromiseOf<F.Return<typeof updatePromise>>
+        type UpdateParams = A.Await<F.Return<typeof updatePromise>>
         type TestUpdateParams = A.Equals<UpdateParams, DocumentClientType.UpdateItemInput>
         const testUpdateParams: TestUpdateParams = 1
         testUpdateParams
@@ -681,7 +684,7 @@ describe('Entity', () => {
       it('no auto-parsing', () => {
         const item = { pk }
         const updatePromise = () => entNoParse.update(item)
-        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type UpdateRawResponse = A.Await<F.Return<typeof updatePromise>>
         type TestUpdateRawResponse = A.Equals<
           UpdateRawResponse,
           DocumentClientType.UpdateItemOutput
@@ -694,7 +697,7 @@ describe('Entity', () => {
         const item = { pk }
         const updatePromise = () =>
           entNoParse.update(item, { parse: true, returnValues: 'ALL_NEW' })
-        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type UpdateItem = A.Await<F.Return<typeof updatePromise>>['Attributes']
         type TestUpdateItem = A.Equals<UpdateItem, ExpectedItem | undefined>
         const testUpdateItem: TestUpdateItem = 1
         testUpdateItem
@@ -703,7 +706,7 @@ describe('Entity', () => {
       it('force no parsing', () => {
         const item = { pk }
         const updatePromise = () => ent.update(item, { parse: false })
-        type UpdateRawResponse = C.PromiseOf<F.Return<typeof updatePromise>>
+        type UpdateRawResponse = A.Await<F.Return<typeof updatePromise>>
         type TestUpdateRawResponse = A.Equals<
           UpdateRawResponse,
           DocumentClientType.UpdateItemOutput
@@ -715,7 +718,7 @@ describe('Entity', () => {
       it('contains no timestamp', () => {
         const item = { pk }
         const updatePromise = () => entNoTimestamps.update(item, { returnValues: 'ALL_NEW' })
-        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type UpdateItem = A.Await<F.Return<typeof updatePromise>>['Attributes']
         type TestUpdateItem = A.Equals<
           UpdateItem,
           Omit<ExpectedItem, 'created' | 'modified'> | undefined
@@ -749,13 +752,13 @@ describe('Entity', () => {
     describe('query method', () => {
       it('nominal case', () => {
         const queryPromise = () => ent.query('pk')
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
         const testQueryItems: TestQueryItems = 1
         testQueryItems
 
-        type QueryNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof queryPromise>>['next'], undefined>>
+        type QueryNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof queryPromise>>['next'], undefined>>
         >['Items']
         type TestQueryNextItems = A.Equals<QueryNextItems, ExpectedItem[] | undefined>
         const testQueryNextItems: TestQueryNextItems = 1
@@ -772,13 +775,13 @@ describe('Entity', () => {
 
       it('force execution', () => {
         const queryPromise = () => ent.query('pk', { execute: true })
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
         const testQueryItems: TestQueryItems = 1
         testQueryItems
 
-        type QueryNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof queryPromise>>['next'], undefined>>
+        type QueryNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof queryPromise>>['next'], undefined>>
         >['Items']
         type TestQueryNextItems = A.Equals<QueryNextItems, ExpectedItem[] | undefined>
         const testQueryNextItems: TestQueryNextItems = 1
@@ -787,7 +790,7 @@ describe('Entity', () => {
 
       it('force no execution', () => {
         const queryPromise = () => ent.query('pk', { execute: false, parse: true })
-        type QueryInput = C.PromiseOf<F.Return<typeof queryPromise>>
+        type QueryInput = A.Await<F.Return<typeof queryPromise>>
         type TestQueryInput = A.Equals<QueryInput, DocumentClientType.QueryInput>
         const testQueryInput: TestQueryInput = 1
         testQueryInput
@@ -795,13 +798,13 @@ describe('Entity', () => {
 
       it('force parsing', () => {
         const queryPromise = () => ent.query('pk', { parse: true })
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
         const testQueryItems: TestQueryItems = 1
         testQueryItems
 
-        type QueryNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof queryPromise>>['next'], undefined>>
+        type QueryNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof queryPromise>>['next'], undefined>>
         >['Items']
         type TestQueryNextItems = A.Equals<QueryNextItems, ExpectedItem[] | undefined>
         const testQueryNextItems: TestQueryNextItems = 1
@@ -810,13 +813,13 @@ describe('Entity', () => {
 
       it('force no parsing', () => {
         const queryPromise = () => ent.query('pk', { parse: false })
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<QueryItems, DocumentClientType.AttributeMap[] | undefined>
         const testQueryItems: TestQueryItems = 1
         testQueryItems
 
-        type QueryNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof queryPromise>>['next'], undefined>>
+        type QueryNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof queryPromise>>['next'], undefined>>
         >['Items']
         type TestQueryNextItems = A.Equals<
           QueryNextItems,
@@ -828,7 +831,7 @@ describe('Entity', () => {
 
       it('contains no timestamp', () => {
         const queryPromise = () => entNoTimestamps.query('pk')
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<
           QueryItems,
           Omit<ExpectedItem, 'created' | 'modified'>[] | undefined
@@ -841,14 +844,14 @@ describe('Entity', () => {
     describe('scan method', () => {
       it('nominal case', () => {
         const scanPromise = () => ent.scan()
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         // TODO: Improve this by parsing table attributes ?
         type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
 
-        type ScanNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof scanPromise>>['next'], undefined>>
+        type ScanNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof scanPromise>>['next'], undefined>>
         >['Items']
         type TestScanNextItems = A.Equals<
           ScanNextItems,
@@ -860,13 +863,13 @@ describe('Entity', () => {
 
       it('force execution', () => {
         const scanPromise = () => ent.scan({ execute: true })
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
 
-        type ScanNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof scanPromise>>['next'], undefined>>
+        type ScanNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof scanPromise>>['next'], undefined>>
         >['Items']
         type TestScanNextItems = A.Equals<
           ScanNextItems,
@@ -878,7 +881,7 @@ describe('Entity', () => {
 
       it('force no execution', () => {
         const scanPromise = () => ent.scan({ execute: false, parse: true })
-        type ScanInput = C.PromiseOf<F.Return<typeof scanPromise>>
+        type ScanInput = A.Await<F.Return<typeof scanPromise>>
         type TestScanInput = A.Equals<ScanInput, DocumentClientType.ScanInput>
         const testScanInput: TestScanInput = 1
         testScanInput
@@ -886,14 +889,14 @@ describe('Entity', () => {
 
       it('force parsing', () => {
         const scanPromise = () => ent.scan({ parse: true })
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         // TODO: Improve this by parsing table attributes ?
         type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
 
-        type ScanNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof scanPromise>>['next'], undefined>>
+        type ScanNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof scanPromise>>['next'], undefined>>
         >['Items']
         type TestScanNextItems = A.Equals<
           ScanNextItems,
@@ -905,13 +908,13 @@ describe('Entity', () => {
 
       it('force no parsing', () => {
         const scanPromise = () => ent.scan({ parse: false })
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
 
-        type ScanNextItems = C.PromiseOf<
-          F.Return<Exclude<C.PromiseOf<F.Return<typeof scanPromise>>['next'], undefined>>
+        type ScanNextItems = A.Await<
+          F.Return<Exclude<A.Await<F.Return<typeof scanPromise>>['next'], undefined>>
         >['Items']
         type TestScanNextItems = A.Equals<
           ScanNextItems,
@@ -1009,7 +1012,7 @@ describe('Entity', () => {
         const ck1 = ck
         ent.getParams(ck1)
         const getPromise1 = () => ent.get(ck1)
-        type GetItem1 = C.PromiseOf<F.Return<typeof getPromise1>>['Item']
+        type GetItem1 = A.Await<F.Return<typeof getPromise1>>['Item']
         type TestGetItem1 = A.Equals<GetItem1, ExpectedItem | undefined>
         const testGetItem1: TestGetItem1 = 1
         testGetItem1
@@ -1017,7 +1020,7 @@ describe('Entity', () => {
         const ck2 = { ...pkMaps, sk }
         ent.getParams(ck2)
         const getPromise2 = () => ent.get(ck2)
-        type GetItem2 = C.PromiseOf<F.Return<typeof getPromise2>>['Item']
+        type GetItem2 = A.Await<F.Return<typeof getPromise2>>['Item']
         type TestGetItem2 = A.Equals<GetItem2, ExpectedItem | undefined>
         const testGetItem2: TestGetItem2 = 1
         testGetItem2
@@ -1025,7 +1028,7 @@ describe('Entity', () => {
         const ck3 = { pk, ...skMaps }
         ent.getParams(ck3)
         const getPromise3 = () => ent.get(ck3)
-        type GetItem3 = C.PromiseOf<F.Return<typeof getPromise3>>['Item']
+        type GetItem3 = A.Await<F.Return<typeof getPromise3>>['Item']
         type TestGetItem3 = A.Equals<GetItem3, ExpectedItem | undefined>
         const testGetItem3: TestGetItem3 = 1
         testGetItem3
@@ -1033,7 +1036,7 @@ describe('Entity', () => {
         const ck4 = ckMaps
         ent.getParams(ck4)
         const getPromise4 = () => ent.get(ck4)
-        type GetItem4 = C.PromiseOf<F.Return<typeof getPromise4>>['Item']
+        type GetItem4 = A.Await<F.Return<typeof getPromise4>>['Item']
         type TestGetItem4 = A.Equals<GetItem4, ExpectedItem | undefined>
         const testGetItem4: TestGetItem4 = 1
         testGetItem4
@@ -1057,7 +1060,7 @@ describe('Entity', () => {
           ent.get(ck, {
             attributes: ['pkMap1', 'skMap1', 'reqAttr', 'optAttr']
           })
-        type GetItemFilt = C.PromiseOf<ReturnType<typeof getPromiseFiltFn>>['Item']
+        type GetItemFilt = A.Await<ReturnType<typeof getPromiseFiltFn>>['Item']
         type TestGetItemFilt = A.Equals<
           GetItemFilt,
           Pick<ExpectedItem, 'pkMap1' | 'skMap1' | 'reqAttr' | 'optAttr'> | undefined
@@ -1103,7 +1106,7 @@ describe('Entity', () => {
         const ck1 = ck
         ent.deleteParams(ck1)
         const deletePromise1 = () => ent.delete(ck1)
-        type DeleteItem1 = C.PromiseOf<
+        type DeleteItem1 = A.Await<
           F.Return<typeof deletePromise1>
           // @ts-expect-error
         >['Attributes']
@@ -1113,7 +1116,7 @@ describe('Entity', () => {
         const ck2 = { pkMap1, pkMap2, sk }
         ent.deleteParams(ck2)
         const deletePromise2 = () => ent.delete(ck2)
-        type DeleteItem2 = C.PromiseOf<
+        type DeleteItem2 = A.Await<
           F.Return<typeof deletePromise2>
           // @ts-expect-error
         >['Attributes']
@@ -1123,7 +1126,7 @@ describe('Entity', () => {
         const ck3 = { pk, skMap1, skMap2 }
         ent.deleteParams(ck3)
         const deletePromise3 = () => ent.delete(ck3, { returnValues: 'NONE' })
-        type DeleteItem3 = C.PromiseOf<
+        type DeleteItem3 = A.Await<
           F.Return<typeof deletePromise3>
           // @ts-expect-error
         >['Attributes']
@@ -1133,7 +1136,7 @@ describe('Entity', () => {
         const ck4 = ckMaps
         ent.deleteParams(ck4)
         const deletePromise4 = () => ent.delete(ck4, { returnValues: 'ALL_OLD' })
-        type DeleteItem4 = C.PromiseOf<F.Return<typeof deletePromise4>>['Attributes']
+        type DeleteItem4 = A.Await<F.Return<typeof deletePromise4>>['Attributes']
         type TestDeleteItem4 = A.Equals<DeleteItem4, ExpectedItem | undefined>
         const testDeleteItem4: TestDeleteItem4 = 1
         testDeleteItem4
@@ -1141,7 +1144,10 @@ describe('Entity', () => {
         type DeleteItemOptions = DeleteOptions<typeof ent>
         type TestDeleteItemOptions = A.Equals<
           DeleteItemOptions,
-          Omit<ExpectedWriteOpts<keyof ExpectedItem | 'hidden', 'NONE' | 'ALL_OLD'>, 'strictSchemaCheck'>
+          Omit<
+            ExpectedWriteOpts<keyof ExpectedItem | 'hidden', 'NONE' | 'ALL_OLD'>,
+            'strictSchemaCheck'
+          >
         >
         const testDeleteItemOptions: TestDeleteItemOptions = 1
         testDeleteItemOptions
@@ -1200,7 +1206,7 @@ describe('Entity', () => {
         ent.putParams(item1)
         const putPromise1 = () => ent.put(item1)
         // @ts-expect-error
-        type PutItem1 = C.PromiseOf<F.Return<typeof putPromise1>>['Attributes']
+        type PutItem1 = A.Await<F.Return<typeof putPromise1>>['Attributes']
         let putItem1: PutItem1
         putItem1
 
@@ -1208,7 +1214,7 @@ describe('Entity', () => {
         ent.putParams(item2)
         const putPromise2 = () => ent.put(item2)
         // @ts-expect-error
-        type PutItem2 = C.PromiseOf<F.Return<typeof putPromise2>>['Attributes']
+        type PutItem2 = A.Await<F.Return<typeof putPromise2>>['Attributes']
         let putItem2: PutItem2
         putItem2
 
@@ -1216,7 +1222,7 @@ describe('Entity', () => {
         ent.putParams(item3)
         const putPromise3 = () => ent.put(item3)
         // @ts-expect-error
-        type PutItem3 = C.PromiseOf<F.Return<typeof putPromise3>>['Attributes']
+        type PutItem3 = A.Await<F.Return<typeof putPromise3>>['Attributes']
         let putItem3: PutItem3
         putItem3
 
@@ -1224,7 +1230,7 @@ describe('Entity', () => {
         ent.putParams(item4)
         const putPromise4 = () => ent.put(item4)
         // @ts-expect-error
-        type PutItem4 = C.PromiseOf<F.Return<typeof putPromise4>>['Attributes']
+        type PutItem4 = A.Await<F.Return<typeof putPromise4>>['Attributes']
         let putItem4: PutItem4
         putItem4
 
@@ -1232,14 +1238,14 @@ describe('Entity', () => {
         ent.putParams(item5)
         const putPromise5 = () => ent.put(item5, { returnValues: 'NONE' })
         // @ts-expect-error
-        type PutItem5 = C.PromiseOf<F.Return<typeof putPromise5>>['Attributes']
+        type PutItem5 = A.Await<F.Return<typeof putPromise5>>['Attributes']
         let putItem5: PutItem5
         putItem5
 
         const item6 = { ...ck, ...existAttrs, ...maps, map2: map2b }
         ent.putParams(item6)
         const putPromise6 = () => ent.put(item6, { returnValues: 'ALL_OLD' })
-        type PutItem6 = C.PromiseOf<F.Return<typeof putPromise6>>['Attributes']
+        type PutItem6 = A.Await<F.Return<typeof putPromise6>>['Attributes']
         type TestPutItem6 = A.Equals<PutItem6, ExpectedItem | undefined>
         const testPutItem6: TestPutItem6 = 1
         testPutItem6
@@ -1334,7 +1340,7 @@ describe('Entity', () => {
         const item1 = { ...testedParams, ...maps }
         ent.updateParams(item1)
         const updatePromise1 = () => ent.update(item1)
-        type UpdateItem1 = C.PromiseOf<
+        type UpdateItem1 = A.Await<
           ReturnType<typeof updatePromise1>
           // @ts-expect-error
         >['Attributes']
@@ -1344,7 +1350,7 @@ describe('Entity', () => {
         const item2 = { ...testedParams, ...existAttrs, ...existAttrsDef }
         ent.updateParams(item2)
         const updatePromise2 = () => ent.update(item2, { returnValues: 'NONE' })
-        type UpdateItem2 = C.PromiseOf<
+        type UpdateItem2 = A.Await<
           ReturnType<typeof updatePromise2>
           // @ts-expect-error
         >['Attributes']
@@ -1354,7 +1360,7 @@ describe('Entity', () => {
         const item3 = { ...omit(testedParams, 'pk'), ...pkMaps }
         ent.updateParams(item3)
         const updatePromise3 = () => ent.update(item3, { returnValues: 'ALL_OLD' })
-        type UpdateItem3 = C.PromiseOf<ReturnType<typeof updatePromise3>>['Attributes']
+        type UpdateItem3 = A.Await<ReturnType<typeof updatePromise3>>['Attributes']
         type TestUpdateItem3 = A.Equals<UpdateItem3, ExpectedItem | undefined>
         const testUpdateItem3: TestUpdateItem3 = 1
         testUpdateItem3
@@ -1362,7 +1368,7 @@ describe('Entity', () => {
         const item4 = { ...omit(testedParams, 'sk'), ...skMaps }
         ent.updateParams(item4)
         const updatePromise4 = () => ent.update(item4, { returnValues: 'ALL_NEW' })
-        type UpdateItem4 = C.PromiseOf<ReturnType<typeof updatePromise4>>['Attributes']
+        type UpdateItem4 = A.Await<ReturnType<typeof updatePromise4>>['Attributes']
         type TestUpdateItem4 = A.Equals<UpdateItem4, ExpectedItem | undefined>
         const testUpdateItem4: TestUpdateItem4 = 1
         testUpdateItem4
@@ -1374,7 +1380,7 @@ describe('Entity', () => {
         }
         ent.updateParams(item5)
         const updatePromise5 = () => ent.update(item5, { returnValues: 'UPDATED_OLD' })
-        type UpdateItem5 = C.PromiseOf<ReturnType<typeof updatePromise5>>['Attributes']
+        type UpdateItem5 = A.Await<ReturnType<typeof updatePromise5>>['Attributes']
         type TestUpdateItem5 = A.Equals<UpdateItem5, ExpectedItem | undefined>
         const testUpdateItem5: TestUpdateItem5 = 1
         testUpdateItem5
@@ -1382,7 +1388,7 @@ describe('Entity', () => {
         const item6 = { ...testedParams, map2: map2b, map4 }
         ent.updateParams(item6)
         const updatePromise6 = () => ent.update(item6, { returnValues: 'UPDATED_NEW' })
-        type UpdateItem6 = C.PromiseOf<ReturnType<typeof updatePromise6>>['Attributes']
+        type UpdateItem6 = A.Await<ReturnType<typeof updatePromise6>>['Attributes']
         type TestUpdateItem6 = A.Equals<UpdateItem6, ExpectedItem | undefined>
         const testUpdateItem6: TestUpdateItem6 = 1
         testUpdateItem6
@@ -1559,7 +1565,7 @@ describe('Entity', () => {
     describe('query method', () => {
       it('nominal case', () => {
         const queryPromise = () => ent.query('pk')
-        type QueryItems = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItems = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItems = A.Equals<QueryItems, ExpectedItem[] | undefined>
         const testQueryItems: TestQueryItems = 1
         testQueryItems
@@ -1577,7 +1583,7 @@ describe('Entity', () => {
     describe('scan method', () => {
       it('nominal case', () => {
         const scanPromise = () => ent.scan()
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
@@ -1640,7 +1646,7 @@ describe('Entity', () => {
         // Regular PK
         ent.getParams(ck1)
         const getPromise1 = () => ent.get(ck1)
-        type GetItem1 = C.PromiseOf<F.Return<typeof getPromise1>>['Item']
+        type GetItem1 = A.Await<F.Return<typeof getPromise1>>['Item']
         type TestGetItem1 = A.Equals<GetItem1, ExpectedItem | undefined>
         const testGetItem1: TestGetItem1 = 1
         testGetItem1
@@ -1649,7 +1655,7 @@ describe('Entity', () => {
         const ck2 = { pkMap1, sk }
         ent.getParams(ck2)
         const getPromise2 = () => ent.get(ck2)
-        type GetItem2 = C.PromiseOf<F.Return<typeof getPromise2>>['Item']
+        type GetItem2 = A.Await<F.Return<typeof getPromise2>>['Item']
         type TestGetItem2 = A.Equals<GetItem2, ExpectedItem | undefined>
         const testGetItem2: TestGetItem2 = 1
         testGetItem2
@@ -1658,7 +1664,7 @@ describe('Entity', () => {
         const ck3 = { pk, skMap1 }
         ent.getParams(ck3)
         const getPromise3 = () => ent.get(ck3)
-        type GetItem3 = C.PromiseOf<F.Return<typeof getPromise3>>['Item']
+        type GetItem3 = A.Await<F.Return<typeof getPromise3>>['Item']
         type TestGetItem3 = A.Equals<GetItem3, ExpectedItem | undefined>
         const testGetItem3: TestGetItem3 = 1
         testGetItem3
@@ -1667,7 +1673,7 @@ describe('Entity', () => {
         const ck4 = { pkMap1 }
         ent.getParams(ck4)
         const getPromise4 = () => ent.get(ck4)
-        type GetItem4 = C.PromiseOf<F.Return<typeof getPromise4>>['Item']
+        type GetItem4 = A.Await<F.Return<typeof getPromise4>>['Item']
         type TestGetItem4 = A.Equals<GetItem4, ExpectedItem | undefined>
         const testGetItem4: TestGetItem4 = 1
         testGetItem4
@@ -1797,14 +1803,14 @@ describe('Entity', () => {
       const ck1 = { sk }
       ent.getParams(ck1)
       const getPromise1 = () => ent.get(ck1)
-      type GetItem1 = C.PromiseOf<F.Return<typeof getPromise1>>['Item']
+      type GetItem1 = A.Await<F.Return<typeof getPromise1>>['Item']
       type TestGetItem1 = A.Equals<GetItem1, ExpectedItem | undefined>
       const testGetItem1: TestGetItem1 = 1
       testGetItem1
 
       ent.getParams(ck2)
       const getPromise2 = () => ent.get(ck2)
-      type GetItem2 = C.PromiseOf<F.Return<typeof getPromise2>>['Item']
+      type GetItem2 = A.Await<F.Return<typeof getPromise2>>['Item']
       type TestGetItem2 = A.Equals<GetItem2, ExpectedItem | undefined>
       const testGetItem2: TestGetItem2 = 1
       testGetItem2
@@ -1919,7 +1925,7 @@ describe('Entity', () => {
 
         it('returned Item should match MethodItemOverlay, even filtered', () => {
           const getPromise = () => ent.get<MethodItemOverlay>(ck)
-          type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+          type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
           type TestGetItem = A.Equals<GetItem, MethodItemOverlay | undefined>
           const testGetItem: TestGetItem = 1
           testGetItem
@@ -1928,7 +1934,7 @@ describe('Entity', () => {
             ent.get<Pick<MethodItemOverlay, 'pk0' | 'sk0' | 'str0'>>(ck, {
               attributes: ['pk0', 'sk0', 'str0']
             })
-          type FilteredGetItem = C.PromiseOf<F.Return<typeof filteredGetPromise>>['Item']
+          type FilteredGetItem = A.Await<F.Return<typeof filteredGetPromise>>['Item']
           type TestFilteredGetItem = A.Equals<
             FilteredGetItem,
             Pick<MethodItemOverlay, 'pk0' | 'sk0' | 'str0'> | undefined
@@ -1959,7 +1965,7 @@ describe('Entity', () => {
 
         it('returned Item should match MethodItemOverlay, even filtered', () => {
           const getPromise = () => ent.get<MethodItemOverlay, MethodCompositeKeyOverlay>(ck0)
-          type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+          type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
           type TestGetItem = A.Equals<GetItem, MethodItemOverlay | undefined>
           const testGetItem: TestGetItem = 1
           testGetItem
@@ -1969,7 +1975,7 @@ describe('Entity', () => {
               ck0,
               { attributes: ['pk0', 'sk0', 'str0'] }
             )
-          type FilteredGetItem = C.PromiseOf<F.Return<typeof filteredGetPromise>>['Item']
+          type FilteredGetItem = A.Await<F.Return<typeof filteredGetPromise>>['Item']
           type TestFilteredGetItem = A.Equals<
             FilteredGetItem,
             Pick<MethodItemOverlay, 'pk0' | 'sk0' | 'str0'> | undefined
@@ -2002,7 +2008,7 @@ describe('Entity', () => {
 
         it('Attributes match MethodItemOverlay', () => {
           const deletePromise = () => ent.delete<MethodItemOverlay>(ck)
-          type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+          type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
           type TestDeleteItem = A.Equals<DeleteItem, MethodItemOverlay | undefined>
           const testDeleteItem: TestDeleteItem = 1
           testDeleteItem
@@ -2030,7 +2036,7 @@ describe('Entity', () => {
 
         it('returned Attributes should match MethodItemOverlay', () => {
           const deletePromise = () => ent.delete<MethodItemOverlay, MethodCompositeKeyOverlay>(ck0)
-          type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+          type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
           type TestDeleteItem = A.Equals<DeleteItem, MethodItemOverlay | undefined>
           const testDeleteItem: TestDeleteItem = 1
           testDeleteItem
@@ -2061,7 +2067,7 @@ describe('Entity', () => {
 
       it('Attributes match MethodItemOverlay', () => {
         const putPromise = () => ent.put<MethodItemOverlay>({ ...ck0, num0 })
-        type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+        type PutItem = A.Await<F.Return<typeof putPromise>>['Attributes']
         type TestPutItem = A.Equals<PutItem, MethodItemOverlay | undefined>
         const testPutItem: TestPutItem = 1
         testPutItem
@@ -2091,7 +2097,7 @@ describe('Entity', () => {
 
       it('Attributes match MethodItemOverlay, whatever the returnValues option is', () => {
         const updatePromise = () => ent.update<MethodItemOverlay>({ ...ck0, num0 })
-        type UpdateItem = C.PromiseOf<F.Return<typeof updatePromise>>['Attributes']
+        type UpdateItem = A.Await<F.Return<typeof updatePromise>>['Attributes']
         type TestUpdateItem = A.Equals<UpdateItem, MethodItemOverlay | undefined>
         const testUpdateItem: TestUpdateItem = 1
         testUpdateItem
@@ -2107,7 +2113,7 @@ describe('Entity', () => {
 
       it('returned Items should match MethodItemOverlay', () => {
         const queryPromise = () => ent.query<MethodItemOverlay>('pk')
-        type QueryItem = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+        type QueryItem = A.Await<F.Return<typeof queryPromise>>['Items']
         type TestQueryItem = A.Equals<QueryItem, MethodItemOverlay[] | undefined>
         const testQueryItem: TestQueryItem = 1
         testQueryItem
@@ -2117,7 +2123,7 @@ describe('Entity', () => {
     describe('scan method', () => {
       it('returned Items should match MethodItemOverlay', () => {
         const scanPromise = () => ent.scan<MethodItemOverlay>()
-        type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+        type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
         type TestScanItems = A.Equals<ScanItems, MethodItemOverlay[] | undefined>
         const testScanItems: TestScanItems = 1
         testScanItems
@@ -2198,13 +2204,13 @@ describe('Entity', () => {
 
         it('returned Item should match EntityItemOverlay, even filtered', () => {
           const getPromise = () => ent.get(ck0)
-          type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+          type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
           type TestGetItem = A.Equals<GetItem, EntityItemOverlay | undefined>
           const testGetItem: TestGetItem = 1
           testGetItem
 
           const filteredGetPromise = () => ent.get(ck0, { attributes: ['pk0', 'sk0', 'str0'] })
-          type FilteredGetItem = C.PromiseOf<F.Return<typeof filteredGetPromise>>['Item']
+          type FilteredGetItem = A.Await<F.Return<typeof filteredGetPromise>>['Item']
           type TestFilteredGetItem = A.Equals<
             FilteredGetItem,
             O.Pick<EntityItemOverlay, 'pk0' | 'sk0' | 'str0'> | undefined
@@ -2238,7 +2244,7 @@ describe('Entity', () => {
 
         it('returned Item should match MethodItemOverlay', () => {
           const getPromise = () => ent.get<MethodItemOverlay>(ck0)
-          type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+          type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
           type TestGetItem = A.Equals<GetItem, MethodItemOverlay | undefined>
           const testGetItem: TestGetItem = 1
           testGetItem
@@ -2273,7 +2279,7 @@ describe('Entity', () => {
 
         it('returned Item should match MethodItemOverlay', () => {
           const getPromise = () => ent.get<MethodItemOverlay, MethodCompositeKeyOverlay>(ck1)
-          type GetItem = C.PromiseOf<F.Return<typeof getPromise>>['Item']
+          type GetItem = A.Await<F.Return<typeof getPromise>>['Item']
           type TestGetItem = A.Equals<GetItem, MethodItemOverlay | undefined>
           const testGetItem: TestGetItem = 1
           testGetItem
@@ -2299,7 +2305,10 @@ describe('Entity', () => {
           type DeleteItemOptions = DeleteOptions<typeof ent>
           type TestDeleteItemOptions = A.Equals<
             DeleteItemOptions,
-            Omit<ExpectedWriteOpts<keyof EntityItemOverlay, 'NONE' | 'ALL_OLD'>, 'strictSchemaCheck'>
+            Omit<
+              ExpectedWriteOpts<keyof EntityItemOverlay, 'NONE' | 'ALL_OLD'>,
+              'strictSchemaCheck'
+            >
           >
           const testDeleteItemOptions: TestDeleteItemOptions = 1
           testDeleteItemOptions
@@ -2307,7 +2316,7 @@ describe('Entity', () => {
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
           const deletePromiseNone1 = () => ent.delete(ck0)
-          type DeleteItemNone1 = C.PromiseOf<
+          type DeleteItemNone1 = A.Await<
             F.Return<typeof deletePromiseNone1>
             // @ts-expect-error
           >['Attributes']
@@ -2315,7 +2324,7 @@ describe('Entity', () => {
           deleteItemNone1
 
           const deletePromiseNone2 = () => ent.delete(ck0, { returnValues: 'NONE' })
-          type DeleteItemNone2 = C.PromiseOf<
+          type DeleteItemNone2 = A.Await<
             F.Return<typeof deletePromiseNone2>
             // @ts-expect-error
           >['Attributes']
@@ -2325,7 +2334,7 @@ describe('Entity', () => {
 
         it('Attributes match EntityItemOverlay if ALL_OLD option is provided', () => {
           const deletePromise = () => ent.delete(ck0, { returnValues: 'ALL_OLD' })
-          type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+          type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
           type TestDeleteItem = A.Equals<DeleteItem, EntityItemOverlay | undefined>
           const testDeleteItem: TestDeleteItem = 1
           testDeleteItem
@@ -2360,7 +2369,7 @@ describe('Entity', () => {
 
         it('Returned Attributes should match MethodItemOverlay', () => {
           const deletePromise = () => ent.delete<MethodItemOverlay>(ck0)
-          type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+          type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
           type TestDeleteItem = A.Equals<DeleteItem, MethodItemOverlay | undefined>
           const testDeleteItem: TestDeleteItem = 1
           testDeleteItem
@@ -2395,7 +2404,7 @@ describe('Entity', () => {
 
         it('Returned Attributes should match MethodItemOverlay', () => {
           const deletePromise = () => ent.delete<MethodItemOverlay, MethodCompositeKeyOverlay>(ck1)
-          type DeleteItem = C.PromiseOf<F.Return<typeof deletePromise>>['Attributes']
+          type DeleteItem = A.Await<F.Return<typeof deletePromise>>['Attributes']
           type TestDeleteItem = A.Equals<DeleteItem, MethodItemOverlay | undefined>
           const testDeleteItem: TestDeleteItem = 1
           testDeleteItem
@@ -2434,7 +2443,7 @@ describe('Entity', () => {
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
           const putPromiseNone1 = () => ent.put({ ...ck0, num0 })
-          type PutItemNone1 = C.PromiseOf<
+          type PutItemNone1 = A.Await<
             F.Return<typeof putPromiseNone1>
             // @ts-expect-error
           >['Attributes']
@@ -2442,7 +2451,7 @@ describe('Entity', () => {
           putItemNone1
 
           const putPromiseNone2 = () => ent.put({ ...ck0, num0 }, { returnValues: 'NONE' })
-          type PutItemNone2 = C.PromiseOf<
+          type PutItemNone2 = A.Await<
             F.Return<typeof putPromiseNone2>
             // @ts-expect-error
           >['Attributes']
@@ -2452,7 +2461,7 @@ describe('Entity', () => {
 
         it('Attributes match EntityItemOverlay if ALL_OLD option is provided', () => {
           const putPromise = () => ent.put({ ...ck0, num0 }, { returnValues: 'ALL_OLD' })
-          type PutItem = C.PromiseOf<F.Return<typeof putPromise>>['Attributes']
+          type PutItem = A.Await<F.Return<typeof putPromise>>['Attributes']
           type TestPutItem = A.Equals<PutItem, EntityItemOverlay | undefined>
           const testPutItem: TestPutItem = 1
           testPutItem
@@ -2491,7 +2500,7 @@ describe('Entity', () => {
 
         it('Attributes match MethodItemOverlay', () => {
           const putOPromise = () => ent.put<MethodItemOverlay>({ ...ck1, num1 })
-          type PutOItem = C.PromiseOf<F.Return<typeof putOPromise>>['Attributes']
+          type PutOItem = A.Await<F.Return<typeof putOPromise>>['Attributes']
           type TestPutOItem = A.Equals<PutOItem, MethodItemOverlay | undefined>
           const testPutOItem: TestPutOItem = 1
           testPutOItem
@@ -2530,7 +2539,7 @@ describe('Entity', () => {
 
         it('Attributes misses from return type if no or none returnValue option is provided', () => {
           const none1UpdatePromise = () => ent.update({ ...ck0, num0 })
-          type None1UpdateAttributes = C.PromiseOf<
+          type None1UpdateAttributes = A.Await<
             F.Return<typeof none1UpdatePromise>
             // @ts-expect-error
           >['Attributes']
@@ -2538,7 +2547,7 @@ describe('Entity', () => {
           none1UpdateAttributes
 
           const none2UpdatePromise = () => ent.update({ ...ck0, num0 }, { returnValues: 'NONE' })
-          type None2UpdateAttributes = C.PromiseOf<
+          type None2UpdateAttributes = A.Await<
             F.Return<typeof none2UpdatePromise>
             // @ts-expect-error
           >['Attributes']
@@ -2549,7 +2558,7 @@ describe('Entity', () => {
         it('Attributes match EntityItemOverlay if UPDATED_OLD, UPDATED_NEW, ALL_OLD & ALL_NEW option is provided', () => {
           const updatedOldUpdatePromise = () =>
             ent.update({ ...ck0, num0 }, { returnValues: 'UPDATED_OLD' })
-          type UpdatedOldUpdateAttributes = C.PromiseOf<
+          type UpdatedOldUpdateAttributes = A.Await<
             F.Return<typeof updatedOldUpdatePromise>
           >['Attributes']
           type AssertUpdatedOldUpdateAttributes = A.Equals<
@@ -2561,7 +2570,7 @@ describe('Entity', () => {
 
           const updatedNewUpdatePromise = () =>
             ent.update({ ...ck0, num0 }, { returnValues: 'UPDATED_NEW' })
-          type UpdatedNewUpdateAttributes = C.PromiseOf<
+          type UpdatedNewUpdateAttributes = A.Await<
             F.Return<typeof updatedNewUpdatePromise>
           >['Attributes']
           type AssertUpdatedNewUpdateAttributes = A.Equals<
@@ -2573,9 +2582,7 @@ describe('Entity', () => {
 
           const allOldUpdatePromise = () =>
             ent.update({ ...ck0, num0 }, { returnValues: 'ALL_OLD' })
-          type AllOldUpdateAttributes = C.PromiseOf<
-            F.Return<typeof allOldUpdatePromise>
-          >['Attributes']
+          type AllOldUpdateAttributes = A.Await<F.Return<typeof allOldUpdatePromise>>['Attributes']
           type AssertAllOldUpdateAttributes = A.Equals<
             AllOldUpdateAttributes,
             EntityItemOverlay | undefined
@@ -2585,9 +2592,7 @@ describe('Entity', () => {
 
           const allNewUpdatePromise = () =>
             ent.update({ ...ck0, num0 }, { returnValues: 'ALL_NEW' })
-          type AllNewUpdateAttributes = C.PromiseOf<
-            F.Return<typeof allNewUpdatePromise>
-          >['Attributes']
+          type AllNewUpdateAttributes = A.Await<F.Return<typeof allNewUpdatePromise>>['Attributes']
           type AssertAllNewUpdateAttributes = A.Equals<
             AllNewUpdateAttributes,
             EntityItemOverlay | undefined
@@ -2630,7 +2635,7 @@ describe('Entity', () => {
 
         it('Attributes match MethodItemOverlay, whatever the returnValues option is', () => {
           const updateO1Promise = () => ent.update<MethodItemOverlay>({ ...ck1, num1 })
-          type UpdateO1Item = C.PromiseOf<F.Return<typeof updateO1Promise>>['Attributes']
+          type UpdateO1Item = A.Await<F.Return<typeof updateO1Promise>>['Attributes']
           type TestUpdateO1Item = A.Equals<UpdateO1Item, MethodItemOverlay | undefined>
           const testUpdateO1Item: TestUpdateO1Item = 1
           testUpdateO1Item
@@ -2648,7 +2653,7 @@ describe('Entity', () => {
 
         it('returned Items should match EntityItemOverlay, even filtered', () => {
           const queryPromise = () => ent.query('pk')
-          type QueryItem = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+          type QueryItem = A.Await<F.Return<typeof queryPromise>>['Items']
           type TestQueryItem = A.Equals<QueryItem, EntityItemOverlay[] | undefined>
           const testQueryItem: TestQueryItem = 1
           testQueryItem
@@ -2662,7 +2667,7 @@ describe('Entity', () => {
           testQueryItemsOptions
 
           const filteredQueryPromise = () => ent.query('pk', { attributes: ['pk0', 'sk0', 'str0'] })
-          type FilteredQueryItem = C.PromiseOf<F.Return<typeof filteredQueryPromise>>['Items']
+          type FilteredQueryItem = A.Await<F.Return<typeof filteredQueryPromise>>['Items']
           type TestFilteredQueryItem = A.Equals<
             FilteredQueryItem,
             Pick<EntityItemOverlay, 'pk0' | 'sk0' | 'str0'>[] | undefined
@@ -2683,7 +2688,7 @@ describe('Entity', () => {
 
         it('returned Items should match MethodItemOverlay', () => {
           const queryPromise = () => ent.query<MethodItemOverlay>('pk')
-          type QueryItem = C.PromiseOf<F.Return<typeof queryPromise>>['Items']
+          type QueryItem = A.Await<F.Return<typeof queryPromise>>['Items']
           type TestQueryItem = A.Equals<QueryItem, MethodItemOverlay[] | undefined>
           const testQueryItem: TestQueryItem = 1
           testQueryItem
@@ -2699,7 +2704,7 @@ describe('Entity', () => {
 
         it('returned Items should not necessarily match EntityItemOverlay', () => {
           const scanPromise = () => ent.scan()
-          type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+          type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
           type TestScanItems = A.Equals<ScanItems, DocumentClientType.AttributeMap[] | undefined>
           const testScanItems: TestScanItems = 1
           testScanItems
@@ -2713,7 +2718,7 @@ describe('Entity', () => {
 
         it('returned Items should match MethodItemOverlay', () => {
           const scanPromise = () => ent.scan<MethodItemOverlay>()
-          type ScanItems = C.PromiseOf<F.Return<typeof scanPromise>>['Items']
+          type ScanItems = A.Await<F.Return<typeof scanPromise>>['Items']
           type TestScanItems = A.Equals<ScanItems, MethodItemOverlay[] | undefined>
           const testScanItems: TestScanItems = 1
           testScanItems

--- a/src/classes/Entity/Entity.ts
+++ b/src/classes/Entity/Entity.ts
@@ -14,7 +14,7 @@ import formatItem from '../../lib/formatItem'
 import getKey from '../../lib/getKey'
 import parseConditions from '../../lib/expressionBuilder'
 import parseProjections from '../../lib/projectionBuilder'
-import { error, transformAttr, isEmpty, If, FirstDefined } from '../../lib/utils'
+import { error, transformAttr, isEmpty, If, FirstDefined, Compute } from '../../lib/utils'
 import {
   ATTRIBUTE_VALUES_LIST_DEFAULT_KEY,
   ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
@@ -44,8 +44,9 @@ import type {
   UpdateItem,
   UpdateOptionsReturnValues,
   Writable,
-  Readonly, $PutBatchOptions,
-} from './types';
+  Readonly,
+  $PutBatchOptions
+} from './types'
 
 class Entity<
   Name extends string = string,
@@ -315,11 +316,11 @@ class Entity<
       If<
         B.Not<ShouldParse<Parse, AutoParse>>,
         DocumentClient.GetItemOutput,
-        A.Compute<
+        Compute<
           O.Update<
             DocumentClient.GetItemOutput,
             'Item',
-            FirstDefined<[MethodItemOverlay, A.Compute<O.Pick<Item, ResponseAttributes>>]>
+            FirstDefined<[MethodItemOverlay, Compute<O.Pick<Item, ResponseAttributes>>]>
           >
         >
       >
@@ -563,7 +564,7 @@ class Entity<
             DocumentClient.DeleteItemOutput,
             'Attributes',
             FirstDefined<
-              [MethodItemOverlay, EntityItemOverlay, A.Compute<O.Pick<Item, ResponseAttributes>>]
+              [MethodItemOverlay, EntityItemOverlay, Compute<O.Pick<Item, ResponseAttributes>>]
             >
           >
         >
@@ -798,13 +799,26 @@ class Entity<
     ReturnValues extends UpdateOptionsReturnValues = 'NONE',
     Execute extends boolean | undefined = undefined,
     Parse extends boolean | undefined = undefined,
-    StrictSchemaCheck extends boolean | undefined= true
+    StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: UpdateItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
-    options: $UpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse, StrictSchemaCheck> = {},
+    item: UpdateItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
+    options: $UpdateOptions<
+      ResponseAttributes,
+      ReturnValues,
+      Execute,
+      Parse,
+      StrictSchemaCheck
+    > = {},
     params: UpdateCustomParams = {}
   ): Promise<
-    A.Compute<
+    Compute<
       If<
         B.Not<ShouldExecute<Execute, AutoExecute>>,
         DocumentClient.UpdateItemInput,
@@ -875,7 +889,14 @@ class Entity<
     ResponseAttributes extends ItemAttributes = ItemAttributes,
     StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: UpdateItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
+    item: UpdateItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
     options: TransactionOptions<ResponseAttributes, StrictSchemaCheck> = {},
     params?: UpdateCustomParams
   ): { Update: DocumentClient.Update } {
@@ -927,8 +948,21 @@ class Entity<
     Parse extends boolean | undefined = undefined,
     StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: UpdateItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
-    options: $UpdateOptions<ResponseAttributes, ReturnValues, Execute, Parse, StrictSchemaCheck> = {},
+    item: UpdateItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
+    options: $UpdateOptions<
+      ResponseAttributes,
+      ReturnValues,
+      Execute,
+      Parse,
+      StrictSchemaCheck
+    > = {},
     {
       SET = [],
       REMOVE = [],
@@ -961,7 +995,7 @@ class Entity<
     // Initialize validateType with the DocumentClient
     const validateType = validateTypes(this.DocumentClient)
 
-     const shouldFilterUnmappedFields = options.strictSchemaCheck === false
+    const shouldFilterUnmappedFields = options.strictSchemaCheck === false
 
     // Merge defaults
     const data = normalizeData(this.DocumentClient)(
@@ -1198,9 +1232,8 @@ class Entity<
 
                   values[`:${value}`] = input.$append
                   // add default list value
-                  values[
-                    `:${ATTRIBUTE_VALUES_LIST_DEFAULT_KEY}`
-                  ] = ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
+                  values[`:${ATTRIBUTE_VALUES_LIST_DEFAULT_KEY}`] =
+                    ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
                 } else if (input.$prepend) {
                   SET.push(
                     `${path} = list_append(:${value}, if_not_exists(${path}, :${ATTRIBUTE_VALUES_LIST_DEFAULT_KEY}))`
@@ -1208,9 +1241,8 @@ class Entity<
 
                   values[`:${value}`] = input.$prepend
                   // add default list value
-                  values[
-                    `:${ATTRIBUTE_VALUES_LIST_DEFAULT_KEY}`
-                  ] = ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
+                  values[`:${ATTRIBUTE_VALUES_LIST_DEFAULT_KEY}`] =
+                    ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
                 } else if (input.$remove) {
                   // console.log('REMOVE:',input.$remove);
                   input.$remove.forEach((i: number) => {
@@ -1310,9 +1342,16 @@ class Entity<
     ReturnValues extends PutOptionsReturnValues = 'NONE',
     Execute extends boolean | undefined = undefined,
     Parse extends boolean | undefined = undefined,
-    StrictSchemaCheck extends boolean | undefined= true
+    StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
+    item: PutItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
     options: $PutOptions<ResponseAttributes, ReturnValues, Execute, Parse, StrictSchemaCheck> = {},
     params: Partial<DocumentClient.PutItemInput> = {}
   ): Promise<
@@ -1330,7 +1369,7 @@ class Entity<
             DocumentClient.PutItemOutput,
             'Attributes',
             FirstDefined<
-              [MethodItemOverlay, EntityItemOverlay, A.Compute<O.Pick<Item, ResponseAttributes>>]
+              [MethodItemOverlay, EntityItemOverlay, Compute<O.Pick<Item, ResponseAttributes>>]
             >
           >
         >
@@ -1387,11 +1426,26 @@ class Entity<
     Execute extends boolean | undefined = undefined,
     Parse extends boolean | undefined = undefined,
     StrictSchemaCheck extends boolean | undefined = true
-    >(
-    item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
+  >(
+    item: PutItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
     options: $PutBatchOptions<Execute, Parse, StrictSchemaCheck> = {}
   ): { [key: string]: DocumentClient.WriteRequest } {
-    const payload = this.putParams<MethodItemOverlay, ShownItemAttributes, ResponseAttributes, 'NONE', Execute, Parse, StrictSchemaCheck>(item, options)
+    const payload = this.putParams<
+      MethodItemOverlay,
+      ShownItemAttributes,
+      ResponseAttributes,
+      'NONE',
+      Execute,
+      Parse,
+      StrictSchemaCheck
+    >(item, options)
     return { [payload.TableName]: { PutRequest: { Item: payload.Item } } }
   }
 
@@ -1413,7 +1467,14 @@ class Entity<
     ResponseAttributes extends ItemAttributes = ItemAttributes,
     StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
+    item: PutItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
     options: TransactionOptions<ResponseAttributes, StrictSchemaCheck> = {},
     params?: Partial<DocumentClient.PutItemInput>
   ): { Put: DocumentClient.Put } {
@@ -1441,7 +1502,6 @@ class Entity<
       StrictSchemaCheck
     >(item, options, params)
 
-
     // If ReturnValues exists, replace with ReturnValuesOnConditionCheckFailure
     if ('ReturnValues' in payload) {
       let { ReturnValues, ..._payload } = payload
@@ -1466,7 +1526,14 @@ class Entity<
     Parse extends boolean | undefined = undefined,
     StrictSchemaCheck extends boolean | undefined = true
   >(
-    item: PutItem<MethodItemOverlay, EntityItemOverlay, CompositePrimaryKey, Item, Attributes, StrictSchemaCheck>,
+    item: PutItem<
+      MethodItemOverlay,
+      EntityItemOverlay,
+      CompositePrimaryKey,
+      Item,
+      Attributes,
+      StrictSchemaCheck
+    >,
     options: $PutOptions<ResponseAttributes, ReturnValues, Execute, Parse, StrictSchemaCheck> = {},
     params: Partial<DocumentClient.PutItemInput> = {}
   ): DocumentClient.PutItemInput {

--- a/src/classes/Entity/types.ts
+++ b/src/classes/Entity/types.ts
@@ -1,7 +1,7 @@
 import type { DocumentClient } from 'aws-sdk/clients/dynamodb'
 import type { A, B, O, F } from 'ts-toolbelt'
 
-import type { FirstDefined, If } from '../../lib/utils'
+import type { Compute, FirstDefined, If } from '../../lib/utils'
 import type { DynamoDBKeyTypes, DynamoDBTypes, $QueryOptions, TableDef } from '../Table';
 import Entity from './Entity'
 

--- a/src/classes/Entity/types.ts
+++ b/src/classes/Entity/types.ts
@@ -1,7 +1,7 @@
 import type { DocumentClient } from 'aws-sdk/clients/dynamodb'
 import type { A, B, O, F } from 'ts-toolbelt'
 
-import type { FirstDefined, If } from '../../lib/utils'
+import { FirstDefined, If, Compute } from '../../lib/utils'
 import type { DynamoDBKeyTypes, DynamoDBTypes, $QueryOptions, TableDef } from '../Table'
 import Entity from './Entity'
 
@@ -292,7 +292,7 @@ export type CompositePrimaryKeyPart<
 export type InferCompositePrimaryKey<
   Item extends O.Object,
   Attributes extends ParsedAttributes
-> = A.Compute<
+> = Compute<
   CompositePrimaryKeyPart<Item, Attributes, 'partitionKey'> &
     CompositePrimaryKeyPart<Item, Attributes, 'sortKey'>
 >
@@ -380,15 +380,19 @@ export type $PutOptions<
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined,
   StrictSchemaCheck extends boolean | undefined = true
-> = O.Partial<$WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues, strictSchemaCheck?: StrictSchemaCheck }>
+> = O.Partial<
+  $WriteOptions<Attributes, Execute, Parse> & {
+    returnValues: ReturnValues
+    strictSchemaCheck?: StrictSchemaCheck
+  }
+>
 
 export type $PutBatchOptions<
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined,
   StrictSchemaCheck extends boolean | undefined = true
 > = O.Partial<
-  Pick<BaseOptions<Execute, Parse>, 'execute' |'parse'>
-  & { strictSchemaCheck?: StrictSchemaCheck }
+  Pick<BaseOptions<Execute, Parse>, 'execute' | 'parse'> & { strictSchemaCheck?: StrictSchemaCheck }
 >
 
 export type PutItem<
@@ -399,18 +403,19 @@ export type PutItem<
   Attributes extends ParsedAttributes,
   StrictSchemaCheck extends boolean | undefined = true
 > = FirstDefined<
-  [
-    MethodItemOverlay,
-    EntityItemOverlay,
-    A.Compute<
-      CompositePrimaryKey &
-        O.Pick<Item, Attributes['always']['input'] | Attributes['required']['input']> &
-        O.Partial<
-          O.Pick<Item, Attributes['always']['default'] | Attributes['required']['default']> &
-            O.Update<Item, Attributes['optional'], A.x | null>
-        >
-    >
-  ] | If<A.Equals<StrictSchemaCheck, true>, never, any>
+  | [
+      MethodItemOverlay,
+      EntityItemOverlay,
+      Compute<
+        CompositePrimaryKey &
+          O.Pick<Item, Attributes['always']['input'] | Attributes['required']['input']> &
+          O.Partial<
+            O.Pick<Item, Attributes['always']['default'] | Attributes['required']['default']> &
+              O.Update<Item, Attributes['optional'], A.x | null>
+          >
+      >
+    ]
+  | If<A.Equals<StrictSchemaCheck, true>, never, any>
 >
 
 export type UpdateOptionsReturnValues =
@@ -426,7 +431,12 @@ export type $UpdateOptions<
   Execute extends boolean | undefined = undefined,
   Parse extends boolean | undefined = undefined,
   StrictSchemaCheck extends boolean | undefined = true
-> = O.Partial<$WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues, strictSchemaCheck?: StrictSchemaCheck }>
+> = O.Partial<
+  $WriteOptions<Attributes, Execute, Parse> & {
+    returnValues: ReturnValues
+    strictSchemaCheck?: StrictSchemaCheck
+  }
+>
 
 export interface UpdateCustomParameters {
   SET: string[]
@@ -445,29 +455,26 @@ export type UpdateItem<
   Attributes extends ParsedAttributes,
   StrictSchemaCheck extends boolean | undefined = true
 > = FirstDefined<
-  [
-    MethodItemOverlay,
-    EntityItemOverlay,
-    A.Compute<
-      CompositePrimaryKey &
-        {
+  | [
+      MethodItemOverlay,
+      EntityItemOverlay,
+      Compute<
+        CompositePrimaryKey & {
           [inputAttr in Attributes['always']['input']]:
             | Item[A.Cast<inputAttr, keyof Item>]
             | { $delete?: string[]; $add?: any; $prepend?: any[]; $append?: any[] }
-        } &
-        {
+        } & {
           [optAttr in Attributes['required']['all'] | Attributes['always']['default']]?:
             | Item[A.Cast<optAttr, keyof Item>]
             | { $delete?: string[]; $add?: any; $prepend?: any[]; $append?: any[] }
-        } &
-        {
+        } & {
           [attr in Attributes['optional']]?:
             | null
             | Item[A.Cast<attr, keyof Item>]
             | { $delete?: string[]; $add?: any; $append?: any[]; $prepend?: any[] }
         } & { $remove?: Attributes['optional'] | Attributes['optional'][] }
-    >
-  ]
+      >
+    ]
   | If<A.Equals<StrictSchemaCheck, true>, never, any>
 >
 
@@ -477,7 +484,7 @@ export type RawDeleteOptions<
   Attributes extends A.Key = A.Key,
   ReturnValues extends DeleteOptionsReturnValues = DeleteOptionsReturnValues,
   Execute extends boolean | undefined = undefined,
-  Parse extends boolean | undefined = undefined,
+  Parse extends boolean | undefined = undefined
 > = O.Partial<$WriteOptions<Attributes, Execute, Parse> & { returnValues: ReturnValues }>
 
 export type TransactionOptionsReturnValues = 'NONE' | 'ALL_OLD'
@@ -485,9 +492,9 @@ export type TransactionOptionsReturnValues = 'NONE' | 'ALL_OLD'
 export interface TransactionOptions<
   Attributes extends A.Key = A.Key,
   StrictSchemaCheck extends boolean | undefined = true
-  > {
+> {
   conditions?: ConditionsOrFilters<Attributes>
-  returnValues?: TransactionOptionsReturnValues,
+  returnValues?: TransactionOptionsReturnValues
   strictSchemaCheck?: StrictSchemaCheck
 }
 
@@ -536,17 +543,16 @@ export type EntityItem<E extends Entity> = E['_typesOnly']['_entityItemOverlay']
   ? E['_typesOnly']['_entityItemOverlay']
   : InferEntityItem<E>
 
-export type ExtractAttributes<
-  E extends Entity
-> = E['_typesOnly']['_entityItemOverlay'] extends Record<A.Key, any>
-  ? ParsedAttributes<keyof E['_typesOnly']['_entityItemOverlay']>
-  : ParseAttributes<
-      A.Cast<O.Writable<E['attributes'], A.Key, 'deep'>, AttributeDefinitions>,
-      E['timestamps'],
-      E['createdAlias'],
-      E['modifiedAlias'],
-      E['typeAlias']
-    >
+export type ExtractAttributes<E extends Entity> =
+  E['_typesOnly']['_entityItemOverlay'] extends Record<A.Key, any>
+    ? ParsedAttributes<keyof E['_typesOnly']['_entityItemOverlay']>
+    : ParseAttributes<
+        A.Cast<O.Writable<E['attributes'], A.Key, 'deep'>, AttributeDefinitions>,
+        E['timestamps'],
+        E['createdAlias'],
+        E['modifiedAlias'],
+        E['typeAlias']
+      >
 
 export type GetOptions<
   E extends Entity,
@@ -561,7 +567,13 @@ export type QueryOptions<
 export type PutOptions<
   E extends Entity,
   A extends ParsedAttributes = ExtractAttributes<E>
-> = $PutOptions<A['all'], PutOptionsReturnValues, boolean | undefined, boolean | undefined, boolean | undefined>
+> = $PutOptions<
+  A['all'],
+  PutOptionsReturnValues,
+  boolean | undefined,
+  boolean | undefined,
+  boolean | undefined
+>
 
 export type DeleteOptions<
   E extends Entity,
@@ -571,4 +583,10 @@ export type DeleteOptions<
 export type UpdateOptions<
   E extends Entity,
   A extends ParsedAttributes = ExtractAttributes<E>
-> = $UpdateOptions<A['all'], UpdateOptionsReturnValues, boolean | undefined, boolean | undefined, boolean | undefined>
+> = $UpdateOptions<
+  A['all'],
+  UpdateOptionsReturnValues,
+  boolean | undefined,
+  boolean | undefined,
+  boolean | undefined
+>

--- a/src/classes/Entity/types.ts
+++ b/src/classes/Entity/types.ts
@@ -456,7 +456,7 @@ export type UpdateItem<MethodItemOverlay extends Overlay,
   StrictSchemaCheck extends boolean | undefined = true> = FirstDefined<[
     MethodItemOverlay,
     EntityItemOverlay,
-    A.Compute<CompositePrimaryKey &
+    Compute<CompositePrimaryKey &
       {
         [inputAttr in Attributes['always']['input'] & keyof Item]: AttributeUpdateInput<Item[inputAttr]>
       } &

--- a/src/classes/Table/Table.ts
+++ b/src/classes/Table/Table.ts
@@ -36,7 +36,7 @@ import type {
 } from './types'
 
 // Import standard error handler
-import { error, conditionError, hasProperty, If } from '../../lib/utils'
+import { error, conditionError, hasProperty, If, Compute } from '../../lib/utils'
 
 // Declare Table class
 class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.Key | null> {
@@ -183,7 +183,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
               break
 
             // For secondary indexes
-            default:
+            default: // end for
               // Verify that the table has this index
               if (!this.Table.indexes[key]) error(`'${key}' is not a valid secondary index name`)
 
@@ -241,7 +241,7 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
                     } // end if
                   } // end if-else
                 } // end if
-              } // end for
+              }
 
               // Check that composite keys define both keys
               // TODO: This only checks for the attribute, not the explicit assignment
@@ -299,8 +299,8 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
                 mappings: {
                   [entity.name]: Object.assign(
                     {
-                      [entity.schema.attributes[attr].alias || attr]: entity.schema.attributes[attr]
-                        .type
+                      [entity.schema.attributes[attr].alias || attr]:
+                        entity.schema.attributes[attr].type
                     },
                     // Add setType if type 'set'
                     entity.schema.attributes[attr].type === 'set'
@@ -358,14 +358,14 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       DocumentClient.QueryInput,
       If<
         A.Equals<Parse, false>,
-        A.Compute<
+        Compute<
           DocumentClient.QueryOutput & {
             next?: () => Promise<DocumentClient.QueryOutput>
           }
         >,
-        A.Compute<
+        Compute<
           O.Update<DocumentClient.QueryOutput, 'Items', Item[]> & {
-            next?: () => Promise<A.Compute<O.Update<DocumentClient.QueryOutput, 'Items', Item[]>>>
+            next?: () => Promise<O.Update<DocumentClient.QueryOutput, 'Items', Item[]>>
           }
         >
       >
@@ -693,14 +693,14 @@ class Table<Name extends string, PartitionKey extends A.Key, SortKey extends A.K
       DocumentClient.ScanInput,
       If<
         A.Equals<Parse, false>,
-        A.Compute<
+        Compute<
           DocumentClient.ScanOutput & {
             next?: () => Promise<DocumentClient.ScanOutput>
           }
         >,
-        A.Compute<
+        Compute<
           O.Update<DocumentClient.ScanOutput, 'Items', Item[]> & {
-            next?: () => Promise<A.Compute<O.Update<DocumentClient.ScanOutput, 'Items', Item[]>>>
+            next?: () => Promise<O.Update<DocumentClient.ScanOutput, 'Items', Item[]>>
           }
         >
       >

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,7 +3,7 @@
  * @author Jeremy Daly <jeremy@jeremydaly.com>
  * @license MIT
  */
-import { A, B, L, O } from 'ts-toolbelt'
+import { A, L } from 'ts-toolbelt'
 
 import { PureAttributeDefinition } from '../classes/Entity'
 import { DynamoDBTypes, DynamoDBKeyTypes } from '../classes/Table'
@@ -79,11 +79,7 @@ export const transformAttr = (mapping: PureAttributeDefinition, value: any, data
 }
 
 // Type now exists in ts-toolbelt but requires upgrading ts: See https://github.com/millsp/ts-toolbelt/issues/169
-export type If<C extends B.Boolean, T, E = never> = C extends B.True
-  ? B.True extends C
-    ? T
-    : E
-  : E
+export type If<C extends 0 | 1, T, E = never> = C extends 1 ? (1 extends C ? T : E) : E
 
 export type FirstDefined<List extends L.List> = {
   stopNone: undefined
@@ -93,3 +89,14 @@ export type FirstDefined<List extends L.List> = {
   If<A.Equals<List, []>, 'stopNone', If<A.Equals<L.Head<List>, undefined>, 'continue', 'stopOne'>>,
   'stopNone' | 'stopOne' | 'continue'
 >]
+
+// ts-toolbelt A.Compute has issues: A.Compute<any[]> returns { [key:string]: any } and A.Compute<unknown> returns {}
+export type Compute<A> = A extends Promise<infer T>
+  ? Promise<Compute<T>>
+  : A extends (...args: infer P) => infer R
+  ? (...args: Compute<P>) => Compute<R>
+  : A extends Set<infer V>
+  ? Set<Compute<V>>
+  : A extends object
+  ? { [key in keyof A]: Compute<A[key]> }
+  : A


### PR DESCRIPTION
PR to upgrade ts-toolbelt to 9.6.0 (using v6 causes a bug on my project, so here I am).

There some format changes because I use prettier and didn't save formatting corrections in a separate commit 😔

Notable changes:
- I updated `If` because `B.True` and `B.False` are not available anymore
- I created a small `Compute` type generic because the one from `ts-toolbelt` is bugged
- I replaced `C.PromiseOf` to `A.Await` (upgrade breaking change)

Otherwise, works fine !