### PR TITLE
fix: resolve missing constants file in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   },
   "files": [
     "dist/index.*",
+    "dist/constants.*",
     "dist/classes/",
     "dist/lib/"
   ]


### PR DESCRIPTION
It seems we're missing a constants file in the files array causing issues when installing with yarn v2.
When I imported this package the `.dist` folder would not contain `constants.js` and `constants.d.ts` which breaks the whole module. 