### PR TITLE
fix(lib/validateTypes): `{ type: 'number', coerce: true }` & `'123.00'` shouldn't throw.

### DIFF
--- a/src/__tests__/validateTypes.unit.test.ts
+++ b/src/__tests__/validateTypes.unit.test.ts
@@ -25,20 +25,78 @@ describe('validateTypes', () => {
     }).toThrow(`'attr' must be of type boolean`)
   })
 
-  it('validates number (int)', async () => {
+  it('validates number (123)', async () => {
     let result = validateTypes(DocumentClient)({ type: 'number' }, 'attr', 123)
     expect(result).toBe(123)
   })
 
-  it('validates number (float)', async () => {
+  it('validates number (1.23)', async () => {
     let result = validateTypes(DocumentClient)({ type: 'number' }, 'attr', 1.23)
     expect(result).toBe(1.23)
   })
 
-  it('fails with invalid number', async () => {
+  it('validates number (0)', async () => {
+    let result = validateTypes(DocumentClient)({ type: 'number' }, 'attr', 0)
+    expect(result).toBe(0)
+  })
+
+  // parseFloat("123.00") === 123 -> String(parseFloat("123.00")) !== "123.00"
+  it('validates number (coerce, float "123.00")', async () => {
+    let result = validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', '123.00')
+    expect(result).toBe(123)
+  })
+
+  it('fails with invalid number (NaN)', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number' }, 'attr', NaN)
+    }).toThrow(`'attr' must be a finite number`)
+  })
+
+  it('fails with invalid number (Infinity)', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number' }, 'attr', Infinity)
+    }).toThrow(`'attr' must be a finite number`)
+  })
+
+  it('fails with invalid number (string)', async () => {
     expect(() => {
       validateTypes(DocumentClient)({ type: 'number' }, 'attr', 'string')
     }).toThrow(`'attr' must be of type number`)
+  })
+
+  // parseInt("123abc"), parseFloat("123abc") === 123
+  it('fails with invalid number (coerce, "123abc")', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', '123abc')
+    }).toThrow(`Could not convert '123abc' to a number for 'attr'`)
+  })
+
+  // Number(true) === 1, Number(false) === 0
+  it('fails with invalid number (coerce, boolean)', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', true)
+    }).toThrow(`Could not convert 'true' to a number for 'attr'`)
+  })
+
+  // Number([]) === 0
+  it('fails with invalid number (coerce, [])', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', [])
+    }).toThrow(`Could not convert '[]' to a number for 'attr'`)
+  })
+
+  // Number([123]) === 123
+  it('fails with invalid number (coerce, [123])', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', [123])
+    }).toThrow(`Could not convert '[123]' to a number for 'attr'`)
+  })
+
+  // Number(null) === 0
+  it('fails with invalid number (coerce, null)', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', null)
+    }).toThrow(`Could not convert 'null' to a number for 'attr'`)
   })
 
   it('validates list', async () => {

--- a/src/__tests__/validateTypes.unit.test.ts
+++ b/src/__tests__/validateTypes.unit.test.ts
@@ -71,6 +71,13 @@ describe('validateTypes', () => {
     }).toThrow(`Could not convert '123abc' to a number for 'attr'`)
   })
 
+  // Number("") === 0
+  it('fails with invalid number (coerce, "")', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', '')
+    }).toThrow(`Could not convert '' to a number for 'attr'`)
+  })
+
   // Number(true) === 1, Number(false) === 0
   it('fails with invalid number (coerce, boolean)', async () => {
     expect(() => {
@@ -92,11 +99,18 @@ describe('validateTypes', () => {
     }).toThrow(`Could not convert '[123]' to a number for 'attr'`)
   })
 
-  // Number(null) === 0
-  it('fails with invalid number (coerce, null)', async () => {
+  // Number("Infinity") === Infinity
+  it('fails with invalid number (coerce, "Infinity")', async () => {
     expect(() => {
-      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', null)
-    }).toThrow(`Could not convert 'null' to a number for 'attr'`)
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', 'Infinity')
+    }).toThrow(`Could not convert 'Infinity' to a number for 'attr'`)
+  })
+
+  // Number("NaN") === NaN
+  it('fails with invalid number (coerce, "NaN")', async () => {
+    expect(() => {
+      validateTypes(DocumentClient)({ type: 'number', coerce: true }, 'attr', 'NaN')
+    }).toThrow(`Could not convert 'NaN' to a number for 'attr'`)
   })
 
   it('validates list', async () => {

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -36,7 +36,7 @@ export default (DocumentClient: DocumentClient) => (mapping: any, field: any, va
 
       const coercedValue = Number(value)
 
-      return typeof value === 'string' && !Number.isNaN(coercedValue)
+      return value && typeof value === 'string' && Number.isFinite(coercedValue)
         ? coercedValue
         : error(
             `Could not convert '${

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -25,14 +25,25 @@ export default (DocumentClient: DocumentClient) => (mapping: any, field: any, va
       return typeof value === 'boolean' || mapping.coerce
         ? toBool(value)
         : error(`'${field}' must be of type boolean`)
-    case 'number':
-      return typeof value === 'number' || mapping.coerce
-        ? String(parseInt(value)) === String(value)
-          ? parseInt(value)
-          : String(parseFloat(value)) === String(value)
-          ? parseFloat(value)
-          : error(`Could not convert '${value}' to a number for '${field}'`)
-        : error(`'${field}' must be of type number`)
+    case 'number': {
+      if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : error(`'${field}' must be a finite number`)
+      }
+
+      if (!mapping.coerce) {
+        return error(`'${field}' must be of type number`)
+      }
+
+      const coercedValue = Number(value)
+
+      return typeof value === 'string' && !Number.isNaN(coercedValue)
+        ? coercedValue
+        : error(
+            `Could not convert '${
+              Array.isArray(value) ? `[${value}]` : value
+            }' to a number for '${field}'`
+          )
+    }
     case 'list':
       return Array.isArray(value)
         ? value
@@ -42,9 +53,7 @@ export default (DocumentClient: DocumentClient) => (mapping: any, field: any, va
             .map(x => x.trim())
         : error(`'${field}' must be a list (array)`)
     case 'map':
-      return value?.constructor === Object
-        ? value
-        : error(`'${field}' must be a map (object)`)
+      return value?.constructor === Object ? value : error(`'${field}' must be a map (object)`)
     case 'set':
       if (Array.isArray(value)) {
         if (!DocumentClient) error('DocumentClient required for this operation')

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -36,7 +36,7 @@ export default (DocumentClient: DocumentClient) => (mapping: any, field: any, va
 
       const coercedValue = Number(value)
 
-      return value && typeof value === 'string' && Number.isFinite(coercedValue)
+      return typeof value === 'string' && Number.isFinite(coercedValue) && value.length > 0
         ? coercedValue
         : error(
             `Could not convert '${


### PR DESCRIPTION
Hey :wave:

closes #78.

Hope ya'll enjoying your weekend! 🍻 