### PR TITLE
fix(entity)!: validate value after applying transform

### DIFF
--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -98,6 +98,16 @@ const TestEntity5 = new Entity({
   table: TestTable2
 })
 
+const TestEntity6 = new Entity({
+  name: 'TestEntity6',
+  autoExecute: false,
+  attributes: {
+    pk: { partitionKey: true },
+    test_number: { type: 'number', transform: () => 'abc' },
+  },
+  table: TestTable2,
+})
+
 describe('put', () => {
   it('creates basic item', () => {
     let { Item } = TestEntity.putParams({ email: 'test-pk', sort: 'test-sk' })
@@ -538,5 +548,12 @@ describe('put', () => {
     })
     expect(Item.sk).toBe('3')
     // expect(TableName).toBe('test-table')
+  })
+
+  it('fail on invalid transformations', () => {
+    expect(() => TestEntity6.putParams({
+      pk: 'test-pk',
+      test_number: 123,
+    })).toThrow("Could not convert 'abc' to a number for 'test_number'")
   })
 })


### PR DESCRIPTION
## Issue
- Validate type function is called before transform function. It allows user to do anything in transform including return invalid values.
- Transform receives abridged value not the one supplied by user due to alterations by validateType
## Fix 
Validate value type after transform. Also fixes #299 and similar issues. 

Transform is supposed to receive (value, data) as arguments where value is supplied value not after type conversions like string to number. ValidateType function does this and various similar conversions for flexibility.