### PR TITLE
docs: add AWS SDK v2 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Create a Table (with the DocumentClient using aws-sdk v2):
 ```typescript
 import DynamoDB from 'aws-sdk/clients/dynamodb'
 
-// const region = 'DynamoDB-Table-Region'
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
   // region,

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ import DynamoDB from 'aws-sdk/clients/dynamodb'
 
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
-  // region,
   convertEmptyValues: false
 })
 

--- a/README.md
+++ b/README.md
@@ -24,15 +24,20 @@ Feedback is welcome and much appreciated! (Huge thanks to [@ThomasAribart](https
 - [GitHub Discussions](https://github.com/jeremydaly/dynamodb-toolbox/discussions)
 
 ## Quick Start
+> :information_source:
+We're using **aws-sdk v2** with DynamoDB tools the support for **aws-sdk v3** is on the way. <br />
+You can read more about the development [here](https://github.com/jeremydaly/dynamodb-toolbox/pull/174).
 
-Install DynamoDB Toolbox:
+Using your favorite package manager, install DynamoDB Toolbox and aws-sdk v2 in your project by running one of the following commands:
 
 ```bash
 # npm
 npm i dynamodb-toolbox
+npm install aws-sdk
 
 # yarn
 yarn add dynamodb-toolbox
+yarn add aws-sdk
 ```
 
 Require or import `Table` and `Entity` from `dynamodb-toolbox`:
@@ -41,13 +46,15 @@ Require or import `Table` and `Entity` from `dynamodb-toolbox`:
 import { Table, Entity } from 'dynamodb-toolbox'
 ```
 
-Create a Table (with the DocumentClient):
+Create a Table (with the DocumentClient using aws-sdk v2):
 
 ```typescript
 import DynamoDB from 'aws-sdk/clients/dynamodb'
 
+// const region = 'DynamoDB-Table-Region'
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
+  // region,
   convertEmptyValues: false
 })
 

--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -36,7 +36,6 @@ import { Table, Entity } from 'dynamodb-toolbox'
 ```typescript title="TypeScript"
 import DynamoDB from 'aws-sdk/clients/dynamodb'
 
-// const region = 'DynamoDB-Table-Region'
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
   // region,

--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -38,7 +38,6 @@ import DynamoDB from 'aws-sdk/clients/dynamodb'
 
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
-  // region,
   convertEmptyValues: false
 })
 ```

--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -2,14 +2,17 @@
 
 ## Install DynamoDB Toolbox
 
-Using your favorite package manager, install DynamoDB Toolbox in your project by running one of the following commands:
+Using your favorite package manager, install DynamoDB Toolbox and aws-sdk v2 in your project by running one of the following commands:
 
 ```bash
 # npm
 npm i dynamodb-toolbox
+npm install aws-sdk
 
 # yarn
 yarn add dynamodb-toolbox
+yarn add aws-sdk
+
 ```
 
 ## Add to your code
@@ -23,14 +26,20 @@ const { Table, Entity } = require('dynamodb-toolbox')
 ```typescript title="TypeScript"
 import { Table, Entity } from 'dynamodb-toolbox'
 ```
+:::info
+We're using **aws-sdk v2** with DynamoDB tools the support for **aws-sdk v3** is on the way. <br />
+You can read more about the development [here](https://github.com/jeremydaly/dynamodb-toolbox/pull/174).
 
-## Load the DocumentClient
+:::
+## Load the DocumentClient using aws-sdk v2
 
-```typescript title="TypeScript
+```typescript title="TypeScript"
 import DynamoDB from 'aws-sdk/clients/dynamodb'
 
+// const region = 'DynamoDB-Table-Region'
 const DocumentClient = new DynamoDB.DocumentClient({
   // Specify your client options as usual
+  // region,
   convertEmptyValues: false
 })
 ```

--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -1,4 +1,9 @@
 # Quick Start
+:::info
+We're using **aws-sdk v2** with DynamoDB tools the support for **aws-sdk v3** is on the way. <br />
+You can read more about the development [here](https://github.com/jeremydaly/dynamodb-toolbox/pull/174).
+
+:::
 
 ## Install DynamoDB Toolbox
 
@@ -26,11 +31,6 @@ const { Table, Entity } = require('dynamodb-toolbox')
 ```typescript title="TypeScript"
 import { Table, Entity } from 'dynamodb-toolbox'
 ```
-:::info
-We're using **aws-sdk v2** with DynamoDB tools the support for **aws-sdk v3** is on the way. <br />
-You can read more about the development [here](https://github.com/jeremydaly/dynamodb-toolbox/pull/174).
-
-:::
 ## Load the DocumentClient using aws-sdk v2
 
 ```typescript title="TypeScript"


### PR DESCRIPTION
- Changes documentation for docusaurus with more information on aws-sdk v2
- Also changes some documentation for Readme.md for this github repo

closes #374 