### PR TITLE
prefix warm attributes builders by _

### DIFF
--- a/src/v1/entity/class.ts
+++ b/src/v1/entity/class.ts
@@ -1,4 +1,4 @@
-import { Item, _HasComputedDefaults, freezeItem, FreezeItem, FrozenItem } from 'v1/item'
+import { _Item, _HasComputedDefaults, freezeItem, FreezeItem, FrozenItem } from 'v1/item'
 import { TableV2, PrimaryKey } from 'v1/table'
 
 import type {
@@ -16,23 +16,23 @@ import { getDefaultComputeKey } from './utils/defaultComputeKey'
 export class EntityV2<
   EntityName extends string = string,
   EntityTable extends TableV2 = TableV2,
-  EntityItem extends Item = Item,
+  EntityItem extends _Item = _Item,
   // TODO: See if possible not to add it as a generic here
   EntityFrozenItem extends FrozenItem = FreezeItem<EntityItem>
 > {
   public type: 'entity'
   public name: EntityName
   public table: EntityTable
-  public item: EntityItem
+  public _item: EntityItem
   public frozenItem: EntityFrozenItem
   // any is needed for contravariance
   computeKey: (
-    keyInput: Item extends EntityItem ? any : KeyInput<EntityFrozenItem>
+    keyInput: _Item extends EntityItem ? any : KeyInput<EntityFrozenItem>
   ) => PrimaryKey<EntityTable>
   // TODO: Split in putComputeDefaults & updateComputeDefaults
   // any is needed for contravariance
   computeDefaults: (
-    putItemInput: Item extends EntityItem ? any : PutItemInput<EntityFrozenItem, true>
+    putItemInput: _Item extends EntityItem ? any : PutItemInput<EntityFrozenItem, true>
   ) => PutItem<EntityFrozenItem>
 
   /**
@@ -48,7 +48,7 @@ export class EntityV2<
   constructor({
     name,
     table,
-    item,
+    item: _item,
     computeKey,
     computeDefaults
   }: {
@@ -66,8 +66,8 @@ export class EntityV2<
     this.table = table
 
     // TODO: validate that item respects table key design
-    this.item = item
-    this.frozenItem = freezeItem(item) as any
+    this._item = _item
+    this.frozenItem = freezeItem(_item) as any
 
     this.computeKey = computeKey ?? (getDefaultComputeKey(this.table) as any)
     this.computeDefaults = computeDefaults ?? (defaultComputeDefaults as any)

--- a/src/v1/entity/generics/KeyInput.ts
+++ b/src/v1/entity/generics/KeyInput.ts
@@ -2,20 +2,20 @@ import type { O } from 'ts-toolbelt'
 
 import type {
   FrozenItem,
-  Item,
+  _Item,
   FrozenAttribute,
-  Attribute,
+  _Attribute,
   ResolvedAttribute,
   FrozenAnyAttribute,
-  AnyAttribute,
+  _AnyAttribute,
   FrozenLeafAttribute,
-  LeafAttribute,
+  _LeafAttribute,
   FrozenSetAttribute,
-  SetAttribute,
+  _SetAttribute,
   FrozenListAttribute,
-  ListAttribute,
+  _ListAttribute,
   FrozenMapAttribute,
-  MapAttribute,
+  _MapAttribute,
   Always
 } from 'v1/item'
 
@@ -60,15 +60,15 @@ export type KeyInput<
   : never
 
 // TODO: Required in Entity constructor... See if possible to use only KeyInput w. FrozenItem
-export type _KeyInput<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type _KeyInput<Input extends EntityV2 | _Item | _Attribute> = Input extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
+  : Input extends _LeafAttribute
   ? NonNullable<Input['_resolved']>
-  : Input extends SetAttribute
+  : Input extends _SetAttribute
   ? Set<_KeyInput<Input['_elements']>>
-  : Input extends ListAttribute
+  : Input extends _ListAttribute
   ? _KeyInput<Input['_elements']>[]
-  : Input extends MapAttribute | Item
+  : Input extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
@@ -87,5 +87,5 @@ export type _KeyInput<Input extends EntityV2 | Item | Attribute> = Input extends
     > & // Add Record<string, ResolvedAttribute> if map is open
       (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
   : Input extends EntityV2
-  ? _KeyInput<Input['item']>
+  ? _KeyInput<Input['_item']>
   : never

--- a/src/v1/entity/generics/NeedsKeyCompute.ts
+++ b/src/v1/entity/generics/NeedsKeyCompute.ts
@@ -1,6 +1,6 @@
 import type { O } from 'ts-toolbelt'
 
-import type { Item, Always } from 'v1/item'
+import type { _Item, Always } from 'v1/item'
 import type { TableV2, IndexableKeyType, HasSK } from 'v1/table'
 
 type Or<PropositionA extends boolean, PropositionB extends boolean> = PropositionA extends true
@@ -10,7 +10,7 @@ type Or<PropositionA extends boolean, PropositionB extends boolean> = Propositio
   : false
 
 type _NeedsKeyPartCompute<
-  ItemInput extends Item,
+  ItemInput extends _Item,
   KeyName extends string,
   KeyType extends IndexableKeyType
 > = ItemInput['_attributes'] extends Record<
@@ -34,7 +34,7 @@ type _NeedsKeyPartCompute<
  * @return Boolean
  */
 export type _NeedsKeyCompute<
-  ItemInput extends Item,
+  ItemInput extends _Item,
   TableInput extends TableV2
 > = HasSK<TableInput> extends true
   ? Or<

--- a/src/v1/entity/generics/PutItem.ts
+++ b/src/v1/entity/generics/PutItem.ts
@@ -1,20 +1,20 @@
 import type { O } from 'ts-toolbelt'
 
 import type {
-  Item,
+  _Item,
   FrozenItem,
-  Attribute,
+  _Attribute,
   FrozenAttribute,
   ResolvedAttribute,
-  AnyAttribute,
+  _AnyAttribute,
   FrozenAnyAttribute,
-  LeafAttribute,
+  _LeafAttribute,
   FrozenLeafAttribute,
-  SetAttribute,
+  _SetAttribute,
   FrozenSetAttribute,
-  ListAttribute,
+  _ListAttribute,
   FrozenListAttribute,
-  MapAttribute,
+  _MapAttribute,
   FrozenMapAttribute,
   AtLeastOnce,
   OnlyOnce,
@@ -59,15 +59,15 @@ export type PutItem<
   : never
 
 // TODO: Required in Entity constructor... See if possible to use only PutItem
-export type _PutItem<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type _PutItem<Input extends EntityV2 | _Item | _Attribute> = Input extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
+  : Input extends _LeafAttribute
   ? NonNullable<Input['_resolved']>
-  : Input extends SetAttribute
+  : Input extends _SetAttribute
   ? Set<_PutItem<Input['_elements']>>
-  : Input extends ListAttribute
+  : Input extends _ListAttribute
   ? _PutItem<Input['_elements']>[]
-  : Input extends MapAttribute | Item
+  : Input extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
@@ -82,5 +82,5 @@ export type _PutItem<Input extends EntityV2 | Item | Attribute> = Input extends 
     > & // Add Record<string, ResolvedAttribute> if map is open
       (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
   : Input extends EntityV2
-  ? _PutItem<Input['item']>
+  ? _PutItem<Input['_item']>
   : never

--- a/src/v1/entity/generics/PutItemInput.ts
+++ b/src/v1/entity/generics/PutItemInput.ts
@@ -1,20 +1,20 @@
 import type { O } from 'ts-toolbelt'
 
 import type {
-  Item,
+  _Item,
   FrozenItem,
-  Attribute,
+  _Attribute,
   FrozenAttribute,
   ResolvedAttribute,
-  AnyAttribute,
+  _AnyAttribute,
   FrozenAnyAttribute,
-  LeafAttribute,
+  _LeafAttribute,
   FrozenLeafAttribute,
-  SetAttribute,
+  _SetAttribute,
   FrozenSetAttribute,
-  ListAttribute,
+  _ListAttribute,
   FrozenListAttribute,
-  MapAttribute,
+  _MapAttribute,
   FrozenMapAttribute,
   AtLeastOnce,
   OnlyOnce,
@@ -70,17 +70,17 @@ export type PutItemInput<
 
 // TODO: Required in Entity constructor... See if possible to use only PutItemInput
 export type _PutItemInput<
-  Input extends EntityV2 | Item | Attribute,
+  Input extends EntityV2 | _Item | _Attribute,
   RequireInitialDefaults extends boolean = false
-> = Input extends AnyAttribute
+> = Input extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
+  : Input extends _LeafAttribute
   ? NonNullable<Input['_resolved']>
-  : Input extends SetAttribute
+  : Input extends _SetAttribute
   ? Set<_PutItemInput<Input['_elements'], RequireInitialDefaults>>
-  : Input extends ListAttribute
+  : Input extends _ListAttribute
   ? _PutItemInput<Input['_elements'], RequireInitialDefaults>[]
-  : Input extends MapAttribute | Item
+  : Input extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
@@ -103,5 +103,5 @@ export type _PutItemInput<
     > & // Add Record<string, ResolvedAttribute> if map is open
       (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
   : Input extends EntityV2
-  ? _PutItemInput<Input['item'], RequireInitialDefaults>
+  ? _PutItemInput<Input['_item'], RequireInitialDefaults>
   : never

--- a/src/v1/item/attributes/any/freeze.ts
+++ b/src/v1/item/attributes/any/freeze.ts
@@ -1,8 +1,8 @@
 import { validateAttributeProperties } from '../shared/validate'
 
-import type { AnyAttribute, FreezeAnyAttribute } from './interface'
+import type { _AnyAttribute, FreezeAnyAttribute } from './interface'
 
-type AnyAttributeFreezer = <Attribute extends AnyAttribute>(
+type AnyAttributeFreezer = <Attribute extends _AnyAttribute>(
   attribute: Attribute,
   path: string
 ) => FreezeAnyAttribute<Attribute>
@@ -14,7 +14,7 @@ type AnyAttributeFreezer = <Attribute extends AnyAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeAnyAttribute: AnyAttributeFreezer = <Attribute extends AnyAttribute>(
+export const freezeAnyAttribute: AnyAttributeFreezer = <Attribute extends _AnyAttribute>(
   attribute: Attribute,
   path: string
 ): FreezeAnyAttribute<Attribute> => {

--- a/src/v1/item/attributes/any/index.ts
+++ b/src/v1/item/attributes/any/index.ts
@@ -1,3 +1,3 @@
 export { any } from './typer'
-export type { AnyAttribute, FrozenAnyAttribute, FreezeAnyAttribute } from './interface'
+export type { _AnyAttribute, FrozenAnyAttribute, FreezeAnyAttribute } from './interface'
 export { freezeAnyAttribute } from './freeze'

--- a/src/v1/item/attributes/any/interface.ts
+++ b/src/v1/item/attributes/any/interface.ts
@@ -6,7 +6,7 @@ import type { AnyAttributeDefaultValue } from './types'
 /**
  * Any attribute interface
  */
-export interface AnyAttribute<
+export interface _AnyAttribute<
   IsRequired extends RequiredOption = RequiredOption,
   IsHidden extends boolean = boolean,
   IsKey extends boolean = boolean,
@@ -26,21 +26,21 @@ export interface AnyAttribute<
    */
   required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
     nextRequired?: NextIsRequired
-  ) => AnyAttribute<NextIsRequired, IsHidden, IsKey, SavedAs, Default>
+  ) => _AnyAttribute<NextIsRequired, IsHidden, IsKey, SavedAs, Default>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => AnyAttribute<IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _AnyAttribute<IsRequired, true, IsKey, SavedAs, Default>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => AnyAttribute<IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _AnyAttribute<IsRequired, IsHidden, true, SavedAs, Default>
   /**
    * Rename attribute before save commands
    */
   savedAs: <NextSavedAs extends string | undefined>(
     nextSavedAs: NextSavedAs
-  ) => AnyAttribute<IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  ) => _AnyAttribute<IsRequired, IsHidden, IsKey, NextSavedAs, Default>
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
@@ -48,7 +48,7 @@ export interface AnyAttribute<
    */
   default: <NextDefaultValue extends AnyAttributeDefaultValue>(
     nextDefaultValue: NextDefaultValue
-  ) => AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, NextDefaultValue>
+  ) => _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, NextDefaultValue>
 }
 
 export interface FrozenAnyAttribute<
@@ -63,7 +63,7 @@ export interface FrozenAnyAttribute<
   path: string
 }
 
-export type FreezeAnyAttribute<Attribute extends AnyAttribute> = FrozenAnyAttribute<
+export type FreezeAnyAttribute<Attribute extends _AnyAttribute> = FrozenAnyAttribute<
   Attribute['_required'],
   Attribute['_hidden'],
   Attribute['_key'],

--- a/src/v1/item/attributes/any/typer.ts
+++ b/src/v1/item/attributes/any/typer.ts
@@ -3,7 +3,7 @@ import type { O } from 'ts-toolbelt'
 import type { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
 
 import type { AnyAttributeDefaultValue } from './types'
-import type { AnyAttribute } from './interface'
+import type { _AnyAttribute } from './interface'
 import { AnyAttributeOptions, ANY_DEFAULT_OPTIONS } from './options'
 
 type AnyAttributeTyper = <
@@ -14,7 +14,7 @@ type AnyAttributeTyper = <
   Default extends AnyAttributeDefaultValue = undefined
 >(
   options?: O.Partial<AnyAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
+) => _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
 
 /**
  * Define a new attribute of any type
@@ -29,7 +29,7 @@ export const any: AnyAttributeTyper = <
   Default extends AnyAttributeDefaultValue = undefined
 >(
   options?: O.Partial<AnyAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+): _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default> => {
   const appliedOptions = { ...ANY_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -53,5 +53,5 @@ export const any: AnyAttributeTyper = <
     key: () => any({ ...appliedOptions, key: true }),
     savedAs: nextSavedAs => any({ ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => any({ ...appliedOptions, default: nextDefault })
-  } as AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
 }

--- a/src/v1/item/attributes/freeze.ts
+++ b/src/v1/item/attributes/freeze.ts
@@ -1,21 +1,23 @@
-import { freezeAnyAttribute, AnyAttribute, FreezeAnyAttribute } from './any'
-import { freezeLeafAttribute, LeafAttribute, FreezeLeafAttribute } from './leaf'
-import { freezeSetAttribute, SetAttribute, FreezeSetAttribute } from './set'
-import { freezeListAttribute, ListAttribute, FreezeListAttribute } from './list'
-import { freezeMapAttribute, MapAttribute, FreezeMapAttribute } from './map'
-import type { Attribute } from './types/attribute'
+import { freezeAnyAttribute, _AnyAttribute, FreezeAnyAttribute } from './any'
+import { freezeLeafAttribute, _LeafAttribute, FreezeLeafAttribute } from './leaf'
+import { freezeSetAttribute, _SetAttribute, FreezeSetAttribute } from './set'
+import { freezeListAttribute, _ListAttribute, FreezeListAttribute } from './list'
+import { freezeMapAttribute, _MapAttribute, FreezeMapAttribute } from './map'
+import type { _Attribute } from './types/attribute'
 
-export type FreezeAttribute<AttributeInput extends Attribute> = AttributeInput extends AnyAttribute
+export type FreezeAttribute<
+  AttributeInput extends _Attribute
+> = AttributeInput extends _AnyAttribute
   ? FreezeAnyAttribute<AttributeInput>
-  : AttributeInput extends LeafAttribute
+  : AttributeInput extends _LeafAttribute
   ? FreezeLeafAttribute<AttributeInput>
-  : AttributeInput extends SetAttribute
+  : AttributeInput extends _SetAttribute
   ? FreezeSetAttribute<AttributeInput>
-  : AttributeInput extends ListAttribute
+  : AttributeInput extends _ListAttribute
   ? FreezeListAttribute<AttributeInput>
-  : AttributeInput extends ListAttribute
+  : AttributeInput extends _ListAttribute
   ? FreezeListAttribute<AttributeInput>
-  : AttributeInput extends MapAttribute
+  : AttributeInput extends _MapAttribute
   ? FreezeMapAttribute<AttributeInput>
   : never
 
@@ -26,7 +28,7 @@ export type FreezeAttribute<AttributeInput extends Attribute> = AttributeInput e
  * @param path _(optional)_ Path of the attribute in the related item (string)
  * @return FrozenAttribute
  */
-export const freezeAttribute = <AttributeInput extends Attribute>(
+export const freezeAttribute = <AttributeInput extends _Attribute>(
   attribute: AttributeInput,
   path: string
 ): FreezeAttribute<AttributeInput> => {

--- a/src/v1/item/attributes/leaf/freeze.ts
+++ b/src/v1/item/attributes/leaf/freeze.ts
@@ -4,10 +4,10 @@ import { validatorsByLeafType } from 'v1/utils/validation'
 
 import { validateAttributeProperties } from '../shared/validate'
 
-import type { LeafAttribute, FreezeLeafAttribute } from './interface'
+import type { _LeafAttribute, FreezeLeafAttribute } from './interface'
 import type { LeafAttributeType, LeafAttributeEnumValues, LeafAttributeDefaultValue } from './types'
 
-type LeafAttributeFreezer = <Attribute extends LeafAttribute>(
+type LeafAttributeFreezer = <Attribute extends _LeafAttribute>(
   attribute: Attribute,
   path: string
 ) => FreezeLeafAttribute<Attribute>
@@ -19,7 +19,7 @@ type LeafAttributeFreezer = <Attribute extends LeafAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeLeafAttribute: LeafAttributeFreezer = <Attribute extends LeafAttribute>(
+export const freezeLeafAttribute: LeafAttributeFreezer = <Attribute extends _LeafAttribute>(
   attribute: Attribute,
   path: string
 ): FreezeLeafAttribute<Attribute> => {

--- a/src/v1/item/attributes/leaf/index.ts
+++ b/src/v1/item/attributes/leaf/index.ts
@@ -4,7 +4,7 @@ export type {
   ResolveLeafAttributeType,
   ResolvedLeafAttributeType
 } from './types'
-export type { LeafAttribute, FrozenLeafAttribute, FreezeLeafAttribute } from './interface'
+export type { _LeafAttribute, FrozenLeafAttribute, FreezeLeafAttribute } from './interface'
 export {
   freezeLeafAttribute,
   InvalidEnumValueTypeError,

--- a/src/v1/item/attributes/leaf/interface.ts
+++ b/src/v1/item/attributes/leaf/interface.ts
@@ -11,7 +11,7 @@ import type {
 /**
  * Leaf attribute interface
  */
-export type LeafAttribute<
+export type _LeafAttribute<
   Type extends LeafAttributeType = LeafAttributeType,
   IsRequired extends RequiredOption = RequiredOption,
   IsHidden extends boolean = boolean,
@@ -37,21 +37,21 @@ export type LeafAttribute<
    */
   required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
     nextRequired?: NextIsRequired
-  ) => LeafAttribute<Type, NextIsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+  ) => _LeafAttribute<Type, NextIsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => LeafAttribute<Type, IsRequired, true, IsKey, SavedAs, Enum, Default>
+  hidden: () => _LeafAttribute<Type, IsRequired, true, IsKey, SavedAs, Enum, Default>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => LeafAttribute<Type, IsRequired, IsHidden, true, SavedAs, Enum, Default>
+  key: () => _LeafAttribute<Type, IsRequired, IsHidden, true, SavedAs, Enum, Default>
   /**
    * Rename attribute before save commands
    */
   savedAs: <NextSavedAs extends string | undefined>(
     nextSavedAs: NextSavedAs
-  ) => LeafAttribute<Type, IsRequired, IsHidden, IsKey, NextSavedAs, Enum, Default>
+  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, NextSavedAs, Enum, Default>
   /**
    * Provide a finite list of possible values for attribute
    * (For typing reasons, enums are only available as attribute methods, not as input options)
@@ -62,7 +62,7 @@ export type LeafAttribute<
    */
   enum: <NextEnum extends ResolveLeafAttributeType<Type>[]>(
     ...nextEnum: NextEnum
-  ) => LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, NextEnum, Default & NextEnum>
+  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, NextEnum, Default & NextEnum>
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
@@ -75,7 +75,7 @@ export type LeafAttribute<
         : unknown)
   >(
     nextDefaultValue: NextDefault
-  ) => LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, NextDefault>
+  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, NextDefault>
 }
 
 export type FrozenLeafAttribute<
@@ -96,7 +96,7 @@ export type FrozenLeafAttribute<
   default: Default
 }
 
-export type FreezeLeafAttribute<Attribute extends LeafAttribute> = FrozenLeafAttribute<
+export type FreezeLeafAttribute<Attribute extends _LeafAttribute> = FrozenLeafAttribute<
   Attribute['_type'],
   Attribute['_required'],
   Attribute['_hidden'],

--- a/src/v1/item/attributes/leaf/typer.ts
+++ b/src/v1/item/attributes/leaf/typer.ts
@@ -2,7 +2,7 @@ import type { O } from 'ts-toolbelt'
 
 import type { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
 
-import type { LeafAttribute } from './interface'
+import type { _LeafAttribute } from './interface'
 import { LeafAttributeOptions, LEAF_DEFAULT_OPTIONS } from './options'
 import type { LeafAttributeType, LeafAttributeEnumValues, LeafAttributeDefaultValue } from './types'
 
@@ -29,7 +29,7 @@ const leaf = <
     Enum,
     Default
   >
-): LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default> => {
+): _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default> => {
   const {
     type: _type,
     required: _required,
@@ -56,7 +56,7 @@ const leaf = <
     savedAs: nextSavedAs => leaf({ ...options, savedAs: nextSavedAs }),
     default: nextDefault => leaf({ ...options, default: nextDefault }),
     enum: (...nextEnum) => leaf({ ...options, _enum: nextEnum })
-  } as LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+  } as _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
 }
 
 type LeafAttributeTyper<Type extends LeafAttributeType> = <
@@ -70,7 +70,7 @@ type LeafAttributeTyper<Type extends LeafAttributeType> = <
   options?: O.Partial<
     LeafAttributeOptions<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
   >
-) => LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
 
 const getLeafAttributeTyper = <Type extends LeafAttributeType>(type: Type) =>
   (<

--- a/src/v1/item/attributes/list/freeze.ts
+++ b/src/v1/item/attributes/list/freeze.ts
@@ -1,9 +1,9 @@
 import { validateAttributeProperties } from '../shared/validate'
 import { freezeAttribute } from '../freeze'
 
-import type { ListAttribute, FreezeListAttribute } from './interface'
+import type { _ListAttribute, FreezeListAttribute } from './interface'
 
-type ListAttributeFreezer = <Attribute extends ListAttribute>(
+type ListAttributeFreezer = <Attribute extends _ListAttribute>(
   attribute: Attribute,
   path: string
 ) => FreezeListAttribute<Attribute>
@@ -15,7 +15,7 @@ type ListAttributeFreezer = <Attribute extends ListAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeListAttribute: ListAttributeFreezer = <Attribute extends ListAttribute>(
+export const freezeListAttribute: ListAttributeFreezer = <Attribute extends _ListAttribute>(
   attribute: Attribute,
   path: string
 ): FreezeListAttribute<Attribute> => {

--- a/src/v1/item/attributes/list/index.ts
+++ b/src/v1/item/attributes/list/index.ts
@@ -1,5 +1,5 @@
 export { list } from './typer'
-export type { ListAttribute, FrozenListAttribute, FreezeListAttribute } from './interface'
+export type { _ListAttribute, FrozenListAttribute, FreezeListAttribute } from './interface'
 export {
   HiddenListAttributeElementsError,
   SavedAsListAttributeElementsError,

--- a/src/v1/item/attributes/list/interface.ts
+++ b/src/v1/item/attributes/list/interface.ts
@@ -7,7 +7,7 @@ import type { ListAttributeElements, FrozenListAttributeElements } from './types
 /**
  * List attribute interface
  */
-export interface ListAttribute<
+export interface _ListAttribute<
   Elements extends ListAttributeElements = ListAttributeElements,
   IsRequired extends RequiredOption = RequiredOption,
   IsHidden extends boolean = boolean,
@@ -29,21 +29,21 @@ export interface ListAttribute<
    */
   required: <NextRequired extends RequiredOption = AtLeastOnce>(
     nextRequired?: NextRequired
-  ) => ListAttribute<Elements, NextRequired, IsHidden, IsKey, SavedAs, Default>
+  ) => _ListAttribute<Elements, NextRequired, IsHidden, IsKey, SavedAs, Default>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => ListAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _ListAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => ListAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _ListAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
   /**
    * Rename attribute before save commands
    */
   savedAs: <NextSavedAs extends string | undefined>(
     nextSavedAs: NextSavedAs
-  ) => ListAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  ) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
   /**
    * Tag attribute as having a computed default value
    *
@@ -51,7 +51,7 @@ export interface ListAttribute<
    */
   default: <NextDefault extends ComputedDefault | undefined>(
     nextDefaultValue: NextDefault
-  ) => ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
+  ) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
 }
 
 export interface FrozenListAttribute<
@@ -68,7 +68,7 @@ export interface FrozenListAttribute<
   path: string
 }
 
-export type FreezeListAttribute<Attribute extends ListAttribute> = FrozenListAttribute<
+export type FreezeListAttribute<Attribute extends _ListAttribute> = FrozenListAttribute<
   FreezeAttribute<Attribute['_elements']>,
   Attribute['_required'],
   Attribute['_hidden'],

--- a/src/v1/item/attributes/list/typer.ts
+++ b/src/v1/item/attributes/list/typer.ts
@@ -3,7 +3,7 @@ import type { O } from 'ts-toolbelt'
 import { ComputedDefault, RequiredOption, Never, AtLeastOnce } from '../constants'
 
 import type { ListAttributeElements } from './types'
-import type { ListAttribute } from './interface'
+import type { _ListAttribute } from './interface'
 import { ListAttributeOptions, LIST_DEFAULT_OPTIONS } from './options'
 
 type ListTyper = <
@@ -16,7 +16,7 @@ type ListTyper = <
 >(
   _elements: Elements,
   options?: O.Partial<ListAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
 
 /**
  * Define a new list attribute
@@ -39,7 +39,7 @@ export const list: ListTyper = <
 >(
   elements: Elements,
   options?: O.Partial<ListAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+): _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
   const appliedOptions = { ...LIST_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -64,5 +64,5 @@ export const list: ListTyper = <
     key: () => list(elements, { ...appliedOptions, key: true }),
     savedAs: nextSavedAs => list(elements, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => list(elements, { ...appliedOptions, default: nextDefault })
-  } as ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
 }

--- a/src/v1/item/attributes/list/types.ts
+++ b/src/v1/item/attributes/list/types.ts
@@ -1,7 +1,7 @@
 import type { AtLeastOnce } from '../constants'
-import type { Attribute, FrozenAttribute } from '../types/attribute'
+import type { _Attribute, FrozenAttribute } from '../types/attribute'
 
-export type ListAttributeElements = Attribute & {
+export type ListAttributeElements = _Attribute & {
   _required: AtLeastOnce
   _hidden: false
   _savedAs: undefined

--- a/src/v1/item/attributes/map/freeze.ts
+++ b/src/v1/item/attributes/map/freeze.ts
@@ -2,9 +2,9 @@ import type { RequiredOption } from '../constants/requiredOptions'
 import { validateAttributeProperties } from '../shared/validate'
 import { freezeAttribute, FreezeAttribute } from '../freeze'
 
-import type { MapAttribute, FreezeMapAttribute } from './interface'
+import type { _MapAttribute, FreezeMapAttribute } from './interface'
 
-type MapAttributeFreezer = <Attribute extends MapAttribute>(
+type MapAttributeFreezer = <Attribute extends _MapAttribute>(
   attribute: Attribute,
   path: string
 ) => FreezeMapAttribute<Attribute>
@@ -16,7 +16,7 @@ type MapAttributeFreezer = <Attribute extends MapAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeMapAttribute: MapAttributeFreezer = <Attribute extends MapAttribute>(
+export const freezeMapAttribute: MapAttributeFreezer = <Attribute extends _MapAttribute>(
   attribute: Attribute,
   path: string
 ): FreezeMapAttribute<Attribute> => {

--- a/src/v1/item/attributes/map/index.ts
+++ b/src/v1/item/attributes/map/index.ts
@@ -1,3 +1,3 @@
-export type { MapAttribute, FrozenMapAttribute, FreezeMapAttribute } from './interface'
+export type { _MapAttribute, FrozenMapAttribute, FreezeMapAttribute } from './interface'
 export { map } from './typer'
 export { freezeMapAttribute } from './freeze'

--- a/src/v1/item/attributes/map/interface.ts
+++ b/src/v1/item/attributes/map/interface.ts
@@ -8,7 +8,7 @@ import type { FreezeAttribute } from '../freeze'
  * MapAttribute attribute interface
  * (Called MapAttribute to differ from native TS Map class)
  */
-export interface MapAttribute<
+export interface _MapAttribute<
   Attributes extends MapAttributeAttributes = MapAttributeAttributes,
   IsRequired extends RequiredOption = RequiredOption,
   IsHidden extends boolean = boolean,
@@ -32,25 +32,25 @@ export interface MapAttribute<
    */
   required: <NextRequired extends RequiredOption = AtLeastOnce>(
     nextRequired?: NextRequired
-  ) => MapAttribute<Attributes, NextRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+  ) => _MapAttribute<Attributes, NextRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => MapAttribute<Attributes, IsRequired, true, IsKey, IsOpen, SavedAs, Default>
+  hidden: () => _MapAttribute<Attributes, IsRequired, true, IsKey, IsOpen, SavedAs, Default>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => MapAttribute<Attributes, IsRequired, IsHidden, true, IsOpen, SavedAs, Default>
+  key: () => _MapAttribute<Attributes, IsRequired, IsHidden, true, IsOpen, SavedAs, Default>
   /**
    * Accept additional attributes of any type
    */
-  open: () => MapAttribute<Attributes, IsRequired, IsHidden, IsKey, true, SavedAs, Default>
+  open: () => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, true, SavedAs, Default>
   /**
    * Rename attribute before save commands
    */
   savedAs: <NextSavedAs extends string | undefined>(
     nextSavedAs: NextSavedAs
-  ) => MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, NextSavedAs, Default>
+  ) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, NextSavedAs, Default>
   /**
    * Tag attribute as having a computed default value
    *
@@ -58,7 +58,7 @@ export interface MapAttribute<
    */
   default: <NextComputeDefault extends ComputedDefault | undefined>(
     nextDefaultValue: NextComputeDefault
-  ) => MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, NextComputeDefault>
+  ) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, NextComputeDefault>
 }
 
 export interface FrozenMapAttribute<
@@ -78,8 +78,8 @@ export interface FrozenMapAttribute<
   requiredAttributesNames: Record<RequiredOption, Set<string>>
 }
 
-export type FreezeMapAttribute<Attribute extends MapAttribute> = FrozenMapAttribute<
-  MapAttribute extends Attribute
+export type FreezeMapAttribute<Attribute extends _MapAttribute> = FrozenMapAttribute<
+  _MapAttribute extends Attribute
     ? FrozenMapAttributeAttributes
     : {
         [key in keyof Attribute['_attributes']]: FreezeAttribute<Attribute['_attributes'][key]>

--- a/src/v1/item/attributes/map/typer.ts
+++ b/src/v1/item/attributes/map/typer.ts
@@ -3,7 +3,7 @@ import type { O } from 'ts-toolbelt'
 import { ComputedDefault, RequiredOption, Never, AtLeastOnce } from '../constants'
 import type { MapAttributeAttributes, Narrow } from '../types'
 
-import type { MapAttribute } from './interface'
+import type { _MapAttribute } from './interface'
 import { MapAttributeOptions, MAPPED_DEFAULT_OPTIONS } from './options'
 
 type MapAttributeAttributeTyper = <
@@ -17,7 +17,7 @@ type MapAttributeAttributeTyper = <
 >(
   _attributes: Narrow<Attributes>,
   options?: O.Partial<MapAttributeOptions<IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>>
-) => MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
 
 /**
  * Define a new map attribute
@@ -36,7 +36,7 @@ export const map: MapAttributeAttributeTyper = <
 >(
   attributes: Narrow<Attributes>,
   options?: O.Partial<MapAttributeOptions<IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>>
-): MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default> => {
+): _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default> => {
   const appliedOptions = { ...MAPPED_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -57,12 +57,12 @@ export const map: MapAttributeAttributeTyper = <
     _savedAs,
     _default,
     required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired: NextIsRequired = 'atLeastOnce' as unknown as NextIsRequired
+      nextRequired: NextIsRequired = ('atLeastOnce' as unknown) as NextIsRequired
     ) => map(attributes, { ...appliedOptions, required: nextRequired }),
     hidden: () => map(attributes, { ...appliedOptions, hidden: true }),
     key: () => map(attributes, { ...appliedOptions, key: true }),
     open: () => map(attributes, { ...appliedOptions, open: true }),
     savedAs: nextSavedAs => map(attributes, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => map(attributes, { ...appliedOptions, default: nextDefault })
-  } as MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+  } as _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
 }

--- a/src/v1/item/attributes/set/freeze.ts
+++ b/src/v1/item/attributes/set/freeze.ts
@@ -1,9 +1,9 @@
 import { validateAttributeProperties } from '../shared/validate'
 import { freezeAttribute } from '../freeze'
 
-import { SetAttribute, FreezeSetAttribute } from './interface'
+import { _SetAttribute, FreezeSetAttribute } from './interface'
 
-type SetAttributeFreezer = <Attribute extends SetAttribute>(
+type SetAttributeFreezer = <Attribute extends _SetAttribute>(
   attribute: Attribute,
   path: string
 ) => FreezeSetAttribute<Attribute>
@@ -15,7 +15,7 @@ type SetAttributeFreezer = <Attribute extends SetAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeSetAttribute: SetAttributeFreezer = <Attribute extends SetAttribute>(
+export const freezeSetAttribute: SetAttributeFreezer = <Attribute extends _SetAttribute>(
   attribute: Attribute,
   path: string
 ): FreezeSetAttribute<Attribute> => {

--- a/src/v1/item/attributes/set/index.ts
+++ b/src/v1/item/attributes/set/index.ts
@@ -1,5 +1,5 @@
 export { set } from './typer'
-export type { SetAttribute, FrozenSetAttribute, FreezeSetAttribute } from './interface'
+export type { _SetAttribute, FrozenSetAttribute, FreezeSetAttribute } from './interface'
 export {
   HiddenSetElementsError,
   SavedAsSetElementsError,

--- a/src/v1/item/attributes/set/interface.ts
+++ b/src/v1/item/attributes/set/interface.ts
@@ -7,7 +7,7 @@ import type { SetAttributeElements, FrozenSetAttributeElements } from './types'
 /**
  * Set attribute interface
  */
-export type SetAttribute<
+export type _SetAttribute<
   Elements extends SetAttributeElements = SetAttributeElements,
   IsRequired extends RequiredOption = RequiredOption,
   IsHidden extends boolean = boolean,
@@ -29,21 +29,21 @@ export type SetAttribute<
    */
   required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
     nextRequired?: NextIsRequired
-  ) => SetAttribute<Elements, NextIsRequired, IsHidden, IsKey, SavedAs, Default>
+  ) => _SetAttribute<Elements, NextIsRequired, IsHidden, IsKey, SavedAs, Default>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => SetAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _SetAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => SetAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _SetAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
   /**
    * Rename attribute before save commands
    */
   savedAs: <NextSavedAs extends string | undefined>(
     nextSavedAs: NextSavedAs
-  ) => SetAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  ) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
@@ -51,7 +51,7 @@ export type SetAttribute<
    */
   default: <NextDefault extends ComputedDefault | undefined>(
     nextDefaultValue: NextDefault
-  ) => SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
+  ) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
 }
 
 export type FrozenSetAttribute<
@@ -68,7 +68,7 @@ export type FrozenSetAttribute<
   default: Default
 }
 
-export type FreezeSetAttribute<Attribute extends SetAttribute> = FrozenSetAttribute<
+export type FreezeSetAttribute<Attribute extends _SetAttribute> = FrozenSetAttribute<
   FreezeAttribute<Attribute['_elements']>,
   Attribute['_required'],
   Attribute['_hidden'],

--- a/src/v1/item/attributes/set/typer.ts
+++ b/src/v1/item/attributes/set/typer.ts
@@ -3,7 +3,7 @@ import type { O } from 'ts-toolbelt'
 import type { RequiredOption, Never, AtLeastOnce } from '../constants/requiredOptions'
 import { ComputedDefault } from '../constants'
 
-import type { SetAttribute } from './interface'
+import type { _SetAttribute } from './interface'
 import { SetAttributeOptions, SET_ATTRIBUTE_DEFAULT_OPTIONS } from './options'
 import type { SetAttributeElements } from './types'
 
@@ -17,7 +17,7 @@ type SetTyper = <
 >(
   _elements: Elements,
   options?: O.Partial<SetAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
 
 /**
  * Define a new set attribute
@@ -40,7 +40,7 @@ export const set: SetTyper = <
 >(
   elements: Elements,
   options?: O.Partial<SetAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+): _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
   const appliedOptions = { ...SET_ATTRIBUTE_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -65,5 +65,5 @@ export const set: SetTyper = <
     key: () => set(elements, { ...appliedOptions, key: true }),
     savedAs: nextSavedAs => set(elements, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => set(elements, { ...appliedOptions, default: nextDefault })
-  } as SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
 }

--- a/src/v1/item/attributes/set/types.ts
+++ b/src/v1/item/attributes/set/types.ts
@@ -1,8 +1,8 @@
 import { AtLeastOnce } from '../constants'
-import type { FrozenLeafAttribute, LeafAttribute } from '../leaf/interface'
+import type { FrozenLeafAttribute, _LeafAttribute } from '../leaf/interface'
 import { LeafAttributeEnumValues } from '../leaf/types'
 
-export type SetAttributeElements = LeafAttribute<
+export type SetAttributeElements = _LeafAttribute<
   'string' | 'number' | 'binary',
   AtLeastOnce,
   false,

--- a/src/v1/item/attributes/types/attribute.ts
+++ b/src/v1/item/attributes/types/attribute.ts
@@ -1,13 +1,18 @@
-import type { AnyAttribute, FrozenAnyAttribute } from '../any'
-import type { LeafAttribute, ResolvedLeafAttributeType, FrozenLeafAttribute } from '../leaf'
-import type { SetAttribute, FrozenSetAttribute } from '../set'
-import type { ListAttribute, FrozenListAttribute } from '../list'
-import type { MapAttribute, FrozenMapAttribute } from '../map'
+import type { _AnyAttribute, FrozenAnyAttribute } from '../any'
+import type { _LeafAttribute, ResolvedLeafAttributeType, FrozenLeafAttribute } from '../leaf'
+import type { _SetAttribute, FrozenSetAttribute } from '../set'
+import type { _ListAttribute, FrozenListAttribute } from '../list'
+import type { _MapAttribute, FrozenMapAttribute } from '../map'
 
 /**
  * Possible attributes types
  */
-export type Attribute = AnyAttribute | LeafAttribute | SetAttribute | ListAttribute | MapAttribute
+export type _Attribute =
+  | _AnyAttribute
+  | _LeafAttribute
+  | _SetAttribute
+  | _ListAttribute
+  | _MapAttribute
 
 export type FrozenAttribute =
   | FrozenAnyAttribute
@@ -20,7 +25,7 @@ export type FrozenAttribute =
  * Dictionary of attributes
  */
 export interface MapAttributeAttributes {
-  [key: string]: Attribute
+  [key: string]: _Attribute
 }
 
 export interface FrozenMapAttributeAttributes {

--- a/src/v1/item/attributes/types/index.ts
+++ b/src/v1/item/attributes/types/index.ts
@@ -1,6 +1,6 @@
 export type { Narrow } from './narrow'
 export type {
-  Attribute,
+  _Attribute,
   FrozenAttribute,
   MapAttributeAttributes,
   FrozenMapAttributeAttributes,

--- a/src/v1/item/attributes/types/narrow.ts
+++ b/src/v1/item/attributes/types/narrow.ts
@@ -1,4 +1,4 @@
-import { MapAttributeAttributes, Attribute } from './attribute'
+import { MapAttributeAttributes, _Attribute } from './attribute'
 
 /**
  * Utility type to narrow the inferred attributes of a map or item
@@ -6,10 +6,10 @@ import { MapAttributeAttributes, Attribute } from './attribute'
  * @param AttributeInput MapAttributeAttributes | Attribute
  * @return MapAttributeAttributes | Attribute
  */
-export type Narrow<AttributeInput extends MapAttributeAttributes | Attribute> = {
+export type Narrow<AttributeInput extends MapAttributeAttributes | _Attribute> = {
   [AttributeProperty in keyof AttributeInput]: AttributeInput[AttributeProperty] extends
     | MapAttributeAttributes
-    | Attribute
+    | _Attribute
     ? Narrow<AttributeInput[AttributeProperty]>
     : AttributeInput[AttributeProperty]
 }

--- a/src/v1/item/freeze.ts
+++ b/src/v1/item/freeze.ts
@@ -1,10 +1,10 @@
-import { Item, FreezeItem } from './interface'
+import { _Item, FreezeItem } from './interface'
 import { FreezeAttribute, freezeAttribute } from './attributes/freeze'
 import { RequiredOption } from './attributes/constants/requiredOptions'
 
-type ItemFreezer = <ItemInput extends Item>(item: ItemInput) => FreezeItem<ItemInput>
+type ItemFreezer = <ItemInput extends _Item>(item: ItemInput) => FreezeItem<ItemInput>
 
-export const freezeItem: ItemFreezer = <ItemInput extends Item>(
+export const freezeItem: ItemFreezer = <ItemInput extends _Item>(
   item: ItemInput
 ): FreezeItem<ItemInput> => {
   const { _type: type, _open: open } = item

--- a/src/v1/item/generics/HasComputedDefaults.ts
+++ b/src/v1/item/generics/HasComputedDefaults.ts
@@ -1,9 +1,9 @@
-import type { Item } from '../interface'
+import type { _Item } from '../interface'
 import type {
-  Attribute,
-  SetAttribute,
-  ListAttribute,
-  MapAttribute,
+  _Attribute,
+  _SetAttribute,
+  _ListAttribute,
+  _MapAttribute,
   ComputedDefault
 } from '../attributes'
 
@@ -14,13 +14,13 @@ import type {
  * @param Input Item | Attribute
  * @return Boolean
  */
-export type _HasComputedDefaults<Input extends Item | Attribute> = Input extends {
+export type _HasComputedDefaults<Input extends _Item | _Attribute> = Input extends {
   _default: ComputedDefault
 }
   ? true
-  : Input extends SetAttribute | ListAttribute
+  : Input extends _SetAttribute | _ListAttribute
   ? _HasComputedDefaults<Input['_elements']>
-  : Input extends MapAttribute | Item
+  : Input extends _MapAttribute | _Item
   ? true extends {
       [K in keyof Input['_attributes']]: _HasComputedDefaults<Input['_attributes'][K]>
     }[keyof Input['_attributes']]

--- a/src/v1/item/index.ts
+++ b/src/v1/item/index.ts
@@ -1,5 +1,5 @@
 export * from './attributes'
 export * from './generics'
-export type { Item, FrozenItem, FreezeItem } from './interface'
+export type { _Item, FrozenItem, FreezeItem } from './interface'
 export { item } from './typer'
 export { freezeItem } from './freeze'

--- a/src/v1/item/interface.ts
+++ b/src/v1/item/interface.ts
@@ -7,7 +7,7 @@ import { FreezeAttribute } from './attributes/freeze'
  * @param MapAttributeAttributesInput Object of attributes
  * @return Item
  */
-export interface Item<
+export interface _Item<
   MapAttributeAttributesInput extends MapAttributeAttributes = MapAttributeAttributes
 > {
   _type: 'item'
@@ -24,7 +24,7 @@ export interface FrozenItem<
   attributes: MapAttributeAttributesInput
 }
 
-export type FreezeItem<ItemInput extends Item> = Item extends ItemInput
+export type FreezeItem<ItemInput extends _Item> = _Item extends ItemInput
   ? FrozenItem
   : FrozenItem<
       {

--- a/src/v1/item/typer.ts
+++ b/src/v1/item/typer.ts
@@ -1,9 +1,9 @@
 import type { MapAttributeAttributes, Narrow } from './attributes/types'
-import type { Item } from './interface'
+import type { _Item } from './interface'
 
 type ItemTyper = <MapAttributeAttributesInput extends MapAttributeAttributes = {}>(
   _attributes: Narrow<MapAttributeAttributesInput>
-) => Item<MapAttributeAttributesInput>
+) => _Item<MapAttributeAttributesInput>
 
 // TODO: Enable item opening
 /**
@@ -14,9 +14,9 @@ type ItemTyper = <MapAttributeAttributesInput extends MapAttributeAttributes = {
  */
 export const item: ItemTyper = <MapAttributeAttributesInput extends MapAttributeAttributes = {}>(
   attributes: Narrow<MapAttributeAttributesInput>
-): Item<MapAttributeAttributesInput> =>
+): _Item<MapAttributeAttributesInput> =>
   ({
     _type: 'item',
     _open: false,
     _attributes: attributes
-  } as Item<MapAttributeAttributesInput>)
+  } as _Item<MapAttributeAttributesInput>)


### PR DESCRIPTION
Prefix "warm" attributes types by `_` to reduce verbosity. Next step is to remove the `Frozen` prefix on "cold" attributes.