### PR TITLE
fix(lib/parseMapping): resolve alias check error on same field

### DIFF
--- a/src/__tests__/parse-alias.unit.test.ts
+++ b/src/__tests__/parse-alias.unit.test.ts
@@ -1,0 +1,44 @@
+// Require Table and Entity classes
+import Table from '../classes/Table'
+import Entity from '../classes/Entity'
+import { DocumentClient } from './bootstrap.test'
+
+const TestEntity = new Entity({
+  name: 'AliasTest',
+  attributes: {
+    pk: { type: 'string', partitionKey: true },
+    sk: { type: 'string', sortKey: true },
+    field: { type: 'set', setType: 'string' }
+  },
+  created: 'timeCreated',
+  createdAlias: 'timeCreated',
+  modified: 'timeUpdated',
+  modifiedAlias: 'timeUpdated'
+})
+
+const TestTable = new Table({
+  name: 'test-alias',
+  partitionKey: 'pk',
+  sortKey: 'sk',
+  entities: [TestEntity],
+  DocumentClient
+})
+
+describe('alias-parse-test', () => {
+  it('success parse item with alias same to field', () => {
+    const item = TestEntity.parse({
+      pk: 'testPk',
+      sk: 'testSk',
+      field: 'someField',
+      timeCreated: '2022-12-01T17:10:00Z',
+      timeUpdated: '2022-12-01T19:10:00Z'
+    })
+    expect(item).toEqual({
+      pk: 'testPk',
+      sk: 'testSk',
+      field: 'someField',
+      timeCreated: '2022-12-01T17:10:00Z',
+      timeUpdated: '2022-12-01T19:10:00Z'
+    })
+  })
+})

--- a/src/__tests__/parse-alias.unit.test.ts
+++ b/src/__tests__/parse-alias.unit.test.ts
@@ -25,7 +25,7 @@ const TestTable = new Table({
 })
 
 describe('alias-parse-test', () => {
-  it('success parse item with alias same to field', () => {
+  it('successfully parse item with alias same as field', () => {
     const item = TestEntity.parse({
       pk: 'testPk',
       sk: 'testSk',

--- a/src/lib/parseMapping.ts
+++ b/src/lib/parseMapping.ts
@@ -55,7 +55,8 @@ export default (
       case 'map':
         if (
           typeof config[prop] !== 'string' ||
-          track.fields.includes((config[prop] || '').trim()) ||
+          // check fields not have alias field except the field itself.
+          (field !== config[prop] && track.fields.includes((config[prop] || '').trim())) ||
           (config[prop] || '').trim().length === 0
         )
           error(`'${prop}' must be a unique string`)

--- a/src/lib/parseMapping.ts
+++ b/src/lib/parseMapping.ts
@@ -55,7 +55,7 @@ export default (
       case 'map':
         if (
           typeof config[prop] !== 'string' ||
-          // check fields not have alias field except the field itself.
+          // check for alias uniqueness
           (field !== config[prop] && track.fields.includes((config[prop] || '').trim())) ||
           (config[prop] || '').trim().length === 0
         )


### PR DESCRIPTION
[Original Issue](https://github.com/jeremydaly/dynamodb-toolbox/issues/85)

* Fix by allow check alias name is same to the field name.