### PR TITLE
use CAPS for generics to distinguish with type constraints

### DIFF
--- a/src/v1/commands/getItem.ts
+++ b/src/v1/commands/getItem.ts
@@ -15,14 +15,14 @@ const hasNoItem = (
  * @param keyInput Key input
  * @return GetItemCommandOutput
  */
-export const getItem = async <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  keyInput: KeyInput<EntityInput>
+export const getItem = async <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  keyInput: KeyInput<ENTITY>
 ): Promise<
-  O.Merge<Omit<GetItemCommandOutput, 'Item'>, { Item?: FormattedItem<EntityInput> | undefined }>
+  O.Merge<Omit<GetItemCommandOutput, 'Item'>, { Item?: FormattedItem<ENTITY> | undefined }>
 > => {
   const commandOutput = await entity.table.dynamoDbClient.send(
-    new GetItemCommand(getItemParams<EntityInput>(entity, keyInput))
+    new GetItemCommand(getItemParams<ENTITY>(entity, keyInput))
   )
 
   if (hasNoItem(commandOutput)) {
@@ -51,9 +51,9 @@ export const getItem = async <EntityInput extends EntityV2>(
  * @param keyInput Key input
  * @return GetItemCommandInput
  */
-export const getItemParams = <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  keyInput: KeyInput<EntityInput>
+export const getItemParams = <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  keyInput: KeyInput<ENTITY>
 ): GetItemCommandInput => {
   const { name: tableName } = entity.table
 

--- a/src/v1/commands/putItem.ts
+++ b/src/v1/commands/putItem.ts
@@ -22,17 +22,17 @@ const hasNoAttributes = (
  * @param putItemInput PutItemInput
  * @return PutItemCommandOutput
  */
-export const putItem = async <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  putItemInput: PutItemInput<EntityInput>
+export const putItem = async <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  putItemInput: PutItemInput<ENTITY>
 ): Promise<
   O.Merge<
     Omit<PutItemCommandOutput, 'Attributes'>,
-    { Attributes?: FormattedItem<EntityInput> | undefined }
+    { Attributes?: FormattedItem<ENTITY> | undefined }
   >
 > => {
   const commandOutput = await entity.table.dynamoDbClient.send(
-    new PutItemCommand(putItemParams<EntityInput>(entity, putItemInput))
+    new PutItemCommand(putItemParams<ENTITY>(entity, putItemInput))
   )
 
   if (hasNoAttributes(commandOutput)) {
@@ -61,9 +61,9 @@ export const putItem = async <EntityInput extends EntityV2>(
  * @param putItemInput Input
  * @return PutItemCommandInput
  */
-export const putItemParams = <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  putItemInput: PutItemInput<EntityInput>
+export const putItemParams = <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  putItemInput: PutItemInput<ENTITY>
 ): PutItemCommandInput => {
   const { name: tableName } = entity.table
 

--- a/src/v1/commands/updateItem.ts
+++ b/src/v1/commands/updateItem.ts
@@ -26,17 +26,17 @@ const hasNoAttributes = (
  * @param updateItemInput Input
  * @return UpdateItemCommandOutput
  */
-export const updateItem = async <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  updateItemInput: UpdateItemInput<EntityInput>
+export const updateItem = async <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  updateItemInput: UpdateItemInput<ENTITY>
 ): Promise<
   O.Merge<
     Omit<UpdateItemCommandOutput, 'Attributes'>,
-    { Attributes?: FormattedItem<EntityInput> | undefined }
+    { Attributes?: FormattedItem<ENTITY> | undefined }
   >
 > => {
   const commandOutput = await entity.table.dynamoDbClient.send(
-    new UpdateItemCommand(updateItemParams<EntityInput>(entity, updateItemInput))
+    new UpdateItemCommand(updateItemParams<ENTITY>(entity, updateItemInput))
   )
 
   if (hasNoAttributes(commandOutput)) {
@@ -65,9 +65,9 @@ export const updateItem = async <EntityInput extends EntityV2>(
  * @param updateItemInput Input
  * @return UpdateItemCommandInput
  */
-export const updateItemParams = <EntityInput extends EntityV2>(
-  entity: EntityInput,
-  updateItemInput: UpdateItemInput<EntityInput>
+export const updateItemParams = <ENTITY extends EntityV2>(
+  entity: ENTITY,
+  updateItemInput: UpdateItemInput<ENTITY>
 ): UpdateItemCommandInput => {
   const { name: tableName } = entity.table
 

--- a/src/v1/entity/class.ts
+++ b/src/v1/entity/class.ts
@@ -14,26 +14,24 @@ import { defaultComputeDefaults } from './utils/defaultComputeDefaults'
 import { getDefaultComputeKey } from './utils/defaultComputeKey'
 
 export class EntityV2<
-  EntityName extends string = string,
-  EntityTable extends TableV2 = TableV2,
-  _EntityItem extends _Item = _Item,
+  NAME extends string = string,
+  TABLE extends TableV2 = TableV2,
+  _ITEM extends _Item = _Item,
   // TODO: See if possible not to add it as a generic here
-  EntityItem extends Item = FreezeItem<_EntityItem>
+  ITEM extends Item = FreezeItem<_ITEM>
 > {
   public type: 'entity'
-  public name: EntityName
-  public table: EntityTable
-  public _item: _EntityItem
-  public item: EntityItem
+  public name: NAME
+  public table: TABLE
+  public _item: _ITEM
+  public item: ITEM
   // any is needed for contravariance
-  computeKey: (
-    keyInput: _Item extends _EntityItem ? any : KeyInput<EntityItem>
-  ) => PrimaryKey<EntityTable>
+  computeKey: (keyInput: _Item extends _ITEM ? any : KeyInput<ITEM>) => PrimaryKey<TABLE>
   // TODO: Split in putComputeDefaults & updateComputeDefaults
   // any is needed for contravariance
   computeDefaults: (
-    putItemInput: _Item extends _EntityItem ? any : PutItemInput<EntityItem, true>
-  ) => PutItem<EntityItem>
+    putItemInput: _Item extends _ITEM ? any : PutItemInput<ITEM, true>
+  ) => PutItem<ITEM>
 
   /**
    * Define an Entity for a given table
@@ -52,14 +50,14 @@ export class EntityV2<
     computeKey,
     computeDefaults
   }: {
-    name: EntityName
-    table: EntityTable
-    item: _EntityItem
-  } & (_NeedsKeyCompute<_EntityItem, EntityTable> extends true
-    ? { computeKey: (keyInput: _KeyInput<_EntityItem>) => PrimaryKey<EntityTable> }
+    name: NAME
+    table: TABLE
+    item: _ITEM
+  } & (_NeedsKeyCompute<_ITEM, TABLE> extends true
+    ? { computeKey: (keyInput: _KeyInput<_ITEM>) => PrimaryKey<TABLE> }
     : { computeKey?: undefined }) &
-    (_HasComputedDefaults<_EntityItem> extends true
-      ? { computeDefaults: (input: _PutItemInput<_EntityItem, true>) => _PutItem<_EntityItem> }
+    (_HasComputedDefaults<_ITEM> extends true
+      ? { computeDefaults: (input: _PutItemInput<_ITEM, true>) => _PutItem<_ITEM> }
       : { computeDefaults?: undefined })) {
     this.type = 'entity'
     this.name = name

--- a/src/v1/entity/generics/FormattedItem.ts
+++ b/src/v1/entity/generics/FormattedItem.ts
@@ -22,31 +22,31 @@ import { EntityV2 } from '../class'
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type FormattedItem<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type FormattedItem<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<FormattedItem<Input['elements']>>
-  : Input extends ListAttribute
-  ? FormattedItem<Input['elements']>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<FormattedItem<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? FormattedItem<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Keep only non-hidden attributes
-          [key in O.SelectKeys<Input['attributes'], { hidden: false }>]: FormattedItem<
-            Input['attributes'][key]
+          [key in O.SelectKeys<INPUT['attributes'], { hidden: false }>]: FormattedItem<
+            INPUT['attributes'][key]
           >
         }
       >,
       // Enforce Required attributes
-      | O.SelectKeys<Input['attributes'], { required: AtLeastOnce | OnlyOnce | Always }>
+      | O.SelectKeys<INPUT['attributes'], { required: AtLeastOnce | OnlyOnce | Always }>
       // Enforce attributes that have defined default (initial or computed)
       // (...but not so sure about that anymore, props can have computed default but still be optional)
-      | O.FilterKeys<Input['attributes'], { default: undefined }>
+      | O.FilterKeys<INPUT['attributes'], { default: undefined }>
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? FormattedItem<Input['item']>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? FormattedItem<INPUT['item']>
   : never

--- a/src/v1/entity/generics/KeyInput.ts
+++ b/src/v1/entity/generics/KeyInput.ts
@@ -27,63 +27,63 @@ import { EntityV2 } from '../class'
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type KeyInput<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type KeyInput<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<KeyInput<Input['elements']>>
-  : Input extends ListAttribute
-  ? KeyInput<Input['elements']>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<KeyInput<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? KeyInput<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Keep only key attributes
-          [key in O.SelectKeys<Input['attributes'], { key: true }>]: KeyInput<
-            Input['attributes'][key]
+          [key in O.SelectKeys<INPUT['attributes'], { key: true }>]: KeyInput<
+            INPUT['attributes'][key]
           >
         }
       >,
       Exclude<
         // Enforce Always Required attributes
-        O.SelectKeys<Input['attributes'], { required: Always }>,
+        O.SelectKeys<INPUT['attributes'], { required: Always }>,
         // ...Except those that have default (not required from user, can be provided by the lib)
-        O.FilterKeys<Input['attributes'], { default: undefined }>
+        O.FilterKeys<INPUT['attributes'], { default: undefined }>
       >
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? KeyInput<Input['item']>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? KeyInput<INPUT['item']>
   : never
 
 // TODO: Required in Entity constructor... See if possible to use only KeyInput w. Item
-export type _KeyInput<Input extends EntityV2 | _Item | _Attribute> = Input extends _AnyAttribute
+export type _KeyInput<INPUT extends EntityV2 | _Item | _Attribute> = INPUT extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends _LeafAttribute
-  ? NonNullable<Input['_resolved']>
-  : Input extends _SetAttribute
-  ? Set<_KeyInput<Input['_elements']>>
-  : Input extends _ListAttribute
-  ? _KeyInput<Input['_elements']>[]
-  : Input extends _MapAttribute | _Item
+  : INPUT extends _LeafAttribute
+  ? NonNullable<INPUT['_resolved']>
+  : INPUT extends _SetAttribute
+  ? Set<_KeyInput<INPUT['_elements']>>
+  : INPUT extends _ListAttribute
+  ? _KeyInput<INPUT['_elements']>[]
+  : INPUT extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
           // Keep only key attributes
-          [key in O.SelectKeys<Input['_attributes'], { _key: true }>]: _KeyInput<
-            Input['_attributes'][key]
+          [key in O.SelectKeys<INPUT['_attributes'], { _key: true }>]: _KeyInput<
+            INPUT['_attributes'][key]
           >
         }
       >,
       Exclude<
         // Enforce Always Required attributes
-        O.SelectKeys<Input['_attributes'], { _required: Always }>,
+        O.SelectKeys<INPUT['_attributes'], { _required: Always }>,
         // ...Except those that have default (not required from user, can be provided by the lib)
-        O.FilterKeys<Input['_attributes'], { _default: undefined }>
+        O.FilterKeys<INPUT['_attributes'], { _default: undefined }>
       >
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? _KeyInput<Input['_item']>
+      (INPUT extends { _open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? _KeyInput<INPUT['_item']>
   : never

--- a/src/v1/entity/generics/NeedsKeyCompute.ts
+++ b/src/v1/entity/generics/NeedsKeyCompute.ts
@@ -3,24 +3,24 @@ import type { O } from 'ts-toolbelt'
 import type { _Item, Always } from 'v1/item'
 import type { TableV2, IndexableKeyType, HasSK } from 'v1/table'
 
-type Or<PropositionA extends boolean, PropositionB extends boolean> = PropositionA extends true
+type Or<BOOL_A extends boolean, BOOL_B extends boolean> = BOOL_A extends true
   ? true
-  : PropositionB extends true
+  : BOOL_B extends true
   ? true
   : false
 
 type _NeedsKeyPartCompute<
-  ItemInput extends _Item,
-  KeyName extends string,
-  KeyType extends IndexableKeyType
-> = ItemInput['_attributes'] extends Record<
-  KeyName,
-  { _type: KeyType; _required: Always; _key: true; _savedAs: undefined }
+  _ITEM extends _Item,
+  KEY_PART_NAME extends string,
+  KEY_PART_TYPE extends IndexableKeyType
+> = _ITEM['_attributes'] extends Record<
+  KEY_PART_NAME,
+  { _type: KEY_PART_TYPE; _required: Always; _key: true; _savedAs: undefined }
 >
   ? false
   : O.SelectKeys<
-      ItemInput['_attributes'],
-      { _type: KeyType; _required: Always; _key: true; _savedAs: KeyName }
+      _ITEM['_attributes'],
+      { _type: KEY_PART_TYPE; _required: Always; _key: true; _savedAs: KEY_PART_NAME }
     > extends never
   ? true
   : false
@@ -33,24 +33,13 @@ type _NeedsKeyPartCompute<
  * @param TableInput Table
  * @return Boolean
  */
-export type _NeedsKeyCompute<
-  ItemInput extends _Item,
-  TableInput extends TableV2
-> = HasSK<TableInput> extends true
+export type _NeedsKeyCompute<_ITEM extends _Item, TABLE extends TableV2> = HasSK<TABLE> extends true
   ? Or<
+      _NeedsKeyPartCompute<_ITEM, TABLE['partitionKey']['name'], TABLE['partitionKey']['type']>,
       _NeedsKeyPartCompute<
-        ItemInput,
-        TableInput['partitionKey']['name'],
-        TableInput['partitionKey']['type']
-      >,
-      _NeedsKeyPartCompute<
-        ItemInput,
-        NonNullable<TableInput['sortKey']>['name'],
-        NonNullable<TableInput['sortKey']>['type']
+        _ITEM,
+        NonNullable<TABLE['sortKey']>['name'],
+        NonNullable<TABLE['sortKey']>['type']
       >
     >
-  : _NeedsKeyPartCompute<
-      ItemInput,
-      TableInput['partitionKey']['name'],
-      TableInput['partitionKey']['type']
-    >
+  : _NeedsKeyPartCompute<_ITEM, TABLE['partitionKey']['name'], TABLE['partitionKey']['type']>

--- a/src/v1/entity/generics/PutItem.ts
+++ b/src/v1/entity/generics/PutItem.ts
@@ -30,55 +30,55 @@ import type { EntityV2 } from '../class'
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type PutItem<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type PutItem<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<PutItem<Input['elements']>>
-  : Input extends ListAttribute
-  ? PutItem<Input['elements']>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<PutItem<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? PutItem<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Keep all attributes
-          [key in keyof Input['attributes']]: PutItem<Input['attributes'][key]>
+          [key in keyof INPUT['attributes']]: PutItem<INPUT['attributes'][key]>
         }
       >,
       // Enforce Required attributes
-      | O.SelectKeys<Input['attributes'], { required: AtLeastOnce | OnlyOnce | Always }>
+      | O.SelectKeys<INPUT['attributes'], { required: AtLeastOnce | OnlyOnce | Always }>
       // Enforce attributes that have initial default
-      | O.FilterKeys<Input['attributes'], { default: undefined | ComputedDefault }>
+      | O.FilterKeys<INPUT['attributes'], { default: undefined | ComputedDefault }>
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? PutItem<Input['item']>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? PutItem<INPUT['item']>
   : never
 
 // TODO: Required in Entity constructor... See if possible to use only PutItem
-export type _PutItem<Input extends EntityV2 | _Item | _Attribute> = Input extends _AnyAttribute
+export type _PutItem<INPUT extends EntityV2 | _Item | _Attribute> = INPUT extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends _LeafAttribute
-  ? NonNullable<Input['_resolved']>
-  : Input extends _SetAttribute
-  ? Set<_PutItem<Input['_elements']>>
-  : Input extends _ListAttribute
-  ? _PutItem<Input['_elements']>[]
-  : Input extends _MapAttribute | _Item
+  : INPUT extends _LeafAttribute
+  ? NonNullable<INPUT['_resolved']>
+  : INPUT extends _SetAttribute
+  ? Set<_PutItem<INPUT['_elements']>>
+  : INPUT extends _ListAttribute
+  ? _PutItem<INPUT['_elements']>[]
+  : INPUT extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
           // Keep all attributes
-          [key in keyof Input['_attributes']]: _PutItem<Input['_attributes'][key]>
+          [key in keyof INPUT['_attributes']]: _PutItem<INPUT['_attributes'][key]>
         }
       >,
       // Enforce Required attributes
-      | O.SelectKeys<Input['_attributes'], { _required: AtLeastOnce | OnlyOnce | Always }>
+      | O.SelectKeys<INPUT['_attributes'], { _required: AtLeastOnce | OnlyOnce | Always }>
       // Enforce attributes that have initial default
-      | O.FilterKeys<Input['_attributes'], { _default: undefined | ComputedDefault }>
+      | O.FilterKeys<INPUT['_attributes'], { _default: undefined | ComputedDefault }>
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? _PutItem<Input['_item']>
+      (INPUT extends { _open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? _PutItem<INPUT['_item']>
   : never

--- a/src/v1/entity/generics/PutItemInput.ts
+++ b/src/v1/entity/generics/PutItemInput.ts
@@ -32,76 +32,76 @@ import type { EntityV2 } from '../class'
  * @return Object
  */
 export type PutItemInput<
-  Input extends EntityV2 | Item | Attribute,
-  RequireInitialDefaults extends boolean = false
-> = Input extends AnyAttribute
+  INPUT extends EntityV2 | Item | Attribute,
+  REQUIRE_INITIAL_DEFAULTS extends boolean = false
+> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<PutItemInput<Input['elements'], RequireInitialDefaults>>
-  : Input extends ListAttribute
-  ? PutItemInput<Input['elements'], RequireInitialDefaults>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<PutItemInput<INPUT['elements'], REQUIRE_INITIAL_DEFAULTS>>
+  : INPUT extends ListAttribute
+  ? PutItemInput<INPUT['elements'], REQUIRE_INITIAL_DEFAULTS>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Keep all attributes
-          [key in keyof Input['attributes']]: PutItemInput<
-            Input['attributes'][key],
-            RequireInitialDefaults
+          [key in keyof INPUT['attributes']]: PutItemInput<
+            INPUT['attributes'][key],
+            REQUIRE_INITIAL_DEFAULTS
           >
         }
       >,
       // Enforce Required attributes except those that have default (will be provided by the lib)
       | O.SelectKeys<
-          Input['attributes'],
+          INPUT['attributes'],
           { required: AtLeastOnce | OnlyOnce | Always; default: undefined }
         >
       // Add attributes with initial (non-computed) defaults if RequireInitialDefaults is true
-      | (RequireInitialDefaults extends true
-          ? O.FilterKeys<Input['attributes'], { default: undefined | ComputedDefault }>
+      | (REQUIRE_INITIAL_DEFAULTS extends true
+          ? O.FilterKeys<INPUT['attributes'], { default: undefined | ComputedDefault }>
           : never)
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? PutItemInput<Input['item'], RequireInitialDefaults>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? PutItemInput<INPUT['item'], REQUIRE_INITIAL_DEFAULTS>
   : never
 
 // TODO: Required in Entity constructor... See if possible to use only PutItemInput
 export type _PutItemInput<
-  Input extends EntityV2 | _Item | _Attribute,
-  RequireInitialDefaults extends boolean = false
-> = Input extends _AnyAttribute
+  INPUT extends EntityV2 | _Item | _Attribute,
+  REQUIRE_INITIAL_DEFAULTS extends boolean = false
+> = INPUT extends _AnyAttribute
   ? ResolvedAttribute
-  : Input extends _LeafAttribute
-  ? NonNullable<Input['_resolved']>
-  : Input extends _SetAttribute
-  ? Set<_PutItemInput<Input['_elements'], RequireInitialDefaults>>
-  : Input extends _ListAttribute
-  ? _PutItemInput<Input['_elements'], RequireInitialDefaults>[]
-  : Input extends _MapAttribute | _Item
+  : INPUT extends _LeafAttribute
+  ? NonNullable<INPUT['_resolved']>
+  : INPUT extends _SetAttribute
+  ? Set<_PutItemInput<INPUT['_elements'], REQUIRE_INITIAL_DEFAULTS>>
+  : INPUT extends _ListAttribute
+  ? _PutItemInput<INPUT['_elements'], REQUIRE_INITIAL_DEFAULTS>[]
+  : INPUT extends _MapAttribute | _Item
   ? O.Required<
       O.Partial<
         {
           // Keep all attributes
-          [key in keyof Input['_attributes']]: _PutItemInput<
-            Input['_attributes'][key],
-            RequireInitialDefaults
+          [key in keyof INPUT['_attributes']]: _PutItemInput<
+            INPUT['_attributes'][key],
+            REQUIRE_INITIAL_DEFAULTS
           >
         }
       >,
       // Enforce Required attributes except those that have default (will be provided by the lib)
       | O.SelectKeys<
-          Input['_attributes'],
+          INPUT['_attributes'],
           { _required: AtLeastOnce | OnlyOnce | Always; _default: undefined }
         >
       // Add attributes with initial (non-computed) defaults if RequireInitialDefaults is true
-      | (RequireInitialDefaults extends true
-          ? O.FilterKeys<Input['_attributes'], { _default: undefined | ComputedDefault }>
+      | (REQUIRE_INITIAL_DEFAULTS extends true
+          ? O.FilterKeys<INPUT['_attributes'], { _default: undefined | ComputedDefault }>
           : never)
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { _open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? _PutItemInput<Input['_item'], RequireInitialDefaults>
+      (INPUT extends { _open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? _PutItemInput<INPUT['_item'], REQUIRE_INITIAL_DEFAULTS>
   : never

--- a/src/v1/entity/generics/SavedItem.ts
+++ b/src/v1/entity/generics/SavedItem.ts
@@ -29,35 +29,35 @@ import type { EntityV2 } from '../class'
  * SwapWithSavedAs<{ keyA: { ...attribute, _savedAs: "keyB" }}>
  * => { keyB: { ...attribute, _savedAs: "keyB"  }}
  */
-type SwapWithSavedAs<MapAttributeAttributesInput extends MapAttributeAttributes> = A.Compute<
+type SwapWithSavedAs<MAP_ATTRIBUTE_ATTRIBUTES extends MapAttributeAttributes> = A.Compute<
   U.IntersectOf<
     {
-      [K in keyof MapAttributeAttributesInput]: MapAttributeAttributesInput[K] extends {
+      [K in keyof MAP_ATTRIBUTE_ATTRIBUTES]: MAP_ATTRIBUTE_ATTRIBUTES[K] extends {
         savedAs: string
       }
-        ? Record<MapAttributeAttributesInput[K]['savedAs'], MapAttributeAttributesInput[K]>
-        : Record<K, MapAttributeAttributesInput[K]>
-    }[keyof MapAttributeAttributesInput]
+        ? Record<MAP_ATTRIBUTE_ATTRIBUTES[K]['savedAs'], MAP_ATTRIBUTE_ATTRIBUTES[K]>
+        : Record<K, MAP_ATTRIBUTE_ATTRIBUTES[K]>
+    }[keyof MAP_ATTRIBUTE_ATTRIBUTES]
   >
 >
 
 type RecSavedItem<
-  Input extends MapAttribute | Item,
-  S extends MapAttributeAttributes = SwapWithSavedAs<Input['attributes']>
+  INPUT extends MapAttribute | Item,
+  SWAPPED_ATTRIBUTES extends MapAttributeAttributes = SwapWithSavedAs<INPUT['attributes']>
 > = O.Required<
   O.Partial<
     {
       // Keep all attributes
-      [key in keyof S]: SavedItem<S[key]>
+      [key in keyof SWAPPED_ATTRIBUTES]: SavedItem<SWAPPED_ATTRIBUTES[key]>
     }
   >,
   // Enforce Required attributes
-  | O.SelectKeys<S, { required: AtLeastOnce | OnlyOnce | Always }>
+  | O.SelectKeys<SWAPPED_ATTRIBUTES, { required: AtLeastOnce | OnlyOnce | Always }>
   // Enforce attributes that have defined default (initial or computed)
   // (...but not so sure about that anymore, props can have computed default but still be optional)
-  | O.FilterKeys<S, { default: undefined }>
+  | O.FilterKeys<SWAPPED_ATTRIBUTES, { default: undefined }>
 > & // Add Record<string, ResolvedAttribute> if map is open
-  (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
 
 /**
  * Shape of saved item in DynamoDB for a given Entity, Item or Attribute
@@ -65,16 +65,16 @@ type RecSavedItem<
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type SavedItem<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type SavedItem<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<SavedItem<Input['elements']>>
-  : Input extends ListAttribute
-  ? SavedItem<Input['elements']>[]
-  : Input extends MapAttribute | Item
-  ? RecSavedItem<Input>
-  : Input extends EntityV2
-  ? SavedItem<Input['item']> & PrimaryKey<Input['table']>
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<SavedItem<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? SavedItem<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
+  ? RecSavedItem<INPUT>
+  : INPUT extends EntityV2
+  ? SavedItem<INPUT['item']> & PrimaryKey<INPUT['table']>
   : never

--- a/src/v1/entity/generics/UpdateItem.ts
+++ b/src/v1/entity/generics/UpdateItem.ts
@@ -22,30 +22,30 @@ import type { EntityV2 } from '../class'
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type UpdateItem<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type UpdateItem<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<UpdateItem<Input['elements']>>
-  : Input extends ListAttribute
-  ? UpdateItem<Input['elements']>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<UpdateItem<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? UpdateItem<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Filter Required OnlyOnce attributes
-          [key in O.FilterKeys<Input['attributes'], { required: OnlyOnce }>]: UpdateItem<
-            Input['attributes'][key]
+          [key in O.FilterKeys<INPUT['attributes'], { required: OnlyOnce }>]: UpdateItem<
+            INPUT['attributes'][key]
           >
         }
       >,
       // Enforce Always Required attributes
-      | O.SelectKeys<Input['attributes'], { required: Always }>
+      | O.SelectKeys<INPUT['attributes'], { required: Always }>
       // Enforce attributes that have initial default
-      | O.FilterKeys<Input['attributes'], { default: undefined | ComputedDefault }>
+      | O.FilterKeys<INPUT['attributes'], { default: undefined | ComputedDefault }>
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? UpdateItem<Input['item']>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? UpdateItem<INPUT['item']>
   : never

--- a/src/v1/entity/generics/UpdateItemInput.ts
+++ b/src/v1/entity/generics/UpdateItemInput.ts
@@ -21,32 +21,32 @@ import type { EntityV2 } from '../class'
  * @param Input Entity | Item | Attribute
  * @return Object
  */
-export type UpdateItemInput<Input extends EntityV2 | Item | Attribute> = Input extends AnyAttribute
+export type UpdateItemInput<INPUT extends EntityV2 | Item | Attribute> = INPUT extends AnyAttribute
   ? ResolvedAttribute
-  : Input extends LeafAttribute
-  ? NonNullable<Input['resolved']>
-  : Input extends SetAttribute
-  ? Set<UpdateItemInput<Input['elements']>>
-  : Input extends ListAttribute
-  ? UpdateItemInput<Input['elements']>[]
-  : Input extends MapAttribute | Item
+  : INPUT extends LeafAttribute
+  ? NonNullable<INPUT['resolved']>
+  : INPUT extends SetAttribute
+  ? Set<UpdateItemInput<INPUT['elements']>>
+  : INPUT extends ListAttribute
+  ? UpdateItemInput<INPUT['elements']>[]
+  : INPUT extends MapAttribute | Item
   ? O.Required<
       O.Partial<
         {
           // Filter Required OnlyOnce attributes
-          [key in O.FilterKeys<Input['attributes'], { required: OnlyOnce }>]: UpdateItemInput<
-            Input['attributes'][key]
+          [key in O.FilterKeys<INPUT['attributes'], { required: OnlyOnce }>]: UpdateItemInput<
+            INPUT['attributes'][key]
           >
         }
       >,
       Exclude<
         // Enforce Required Always attributes...
-        O.SelectKeys<Input['attributes'], { required: Always }>,
+        O.SelectKeys<INPUT['attributes'], { required: Always }>,
         // ...Except those that have default (not required from user, can be provided by the lib)
-        O.FilterKeys<Input['attributes'], { default: undefined }>
+        O.FilterKeys<INPUT['attributes'], { default: undefined }>
       >
     > & // Add Record<string, ResolvedAttribute> if map is open
-      (Input extends { open: true } ? Record<string, ResolvedAttribute> : {})
-  : Input extends EntityV2
-  ? UpdateItemInput<Input['item']>
+      (INPUT extends { open: true } ? Record<string, ResolvedAttribute> : {})
+  : INPUT extends EntityV2
+  ? UpdateItemInput<INPUT['item']>
   : never

--- a/src/v1/entity/utils/formatter.ts
+++ b/src/v1/entity/utils/formatter.ts
@@ -2,13 +2,13 @@ import type { EntityV2 } from '../class'
 import type { FormattedItem, SavedItem } from '../generics'
 
 type Formatter = <
-  EntityInput extends EntityV2,
-  EntitySavedItem extends Record<string, any> = SavedItem<EntityInput>,
-  EntityFormattedItem extends Record<string, any> = FormattedItem<EntityInput>
+  ENTITY extends EntityV2,
+  SAVED_ITEM extends Record<string, any> = SavedItem<ENTITY>,
+  FORMATTED_ITEM extends Record<string, any> = FormattedItem<ENTITY>
 >(
-  entity: EntityInput,
-  savedItem: EntitySavedItem
-) => EntityFormattedItem
+  entity: ENTITY,
+  savedItem: SAVED_ITEM
+) => FORMATTED_ITEM
 
 /**
  * Format saved item in DynamoDB to desired output for a given Entity

--- a/src/v1/entity/utils/validateKeyInput.ts
+++ b/src/v1/entity/utils/validateKeyInput.ts
@@ -15,9 +15,9 @@ import type { KeyInput } from '../generics'
 
 type ValidationContext = { elementsIndexes?: number[] }
 
-type KeyInputValidator = <Input extends EntityV2 | Item | Attribute>(
-  entity: Input,
-  keyInput: KeyInput<Input>,
+type KeyInputValidator = <INPUT extends EntityV2 | Item | Attribute>(
+  entity: INPUT,
+  keyInput: KeyInput<INPUT>,
   context?: ValidationContext
 ) => void
 
@@ -29,9 +29,9 @@ type KeyInputValidator = <Input extends EntityV2 | Item | Attribute>(
  * @param path _(optional)_ Path of the attribute in the related item (string)
  * @return void
  */
-export const validateKeyInput: KeyInputValidator = <Input extends EntityV2 | Item | Attribute>(
-  entry: Input,
-  keyInput: KeyInput<Input>,
+export const validateKeyInput: KeyInputValidator = <INPUT extends EntityV2 | Item | Attribute>(
+  entry: INPUT,
+  keyInput: KeyInput<INPUT>,
   context: ValidationContext = {}
 ): void => {
   if (entry.type === 'entity') {

--- a/src/v1/entity/utils/validatePutItemInput.ts
+++ b/src/v1/entity/utils/validatePutItemInput.ts
@@ -2,12 +2,12 @@ import type { EntityV2 } from '../class'
 import type { PutItemInput } from '../generics'
 
 type PutItemInputValidator = <
-  EntityInput extends EntityV2,
-  EntityPutItemInput extends Record<string, any> = PutItemInput<EntityInput>
+  ENTITY extends EntityV2,
+  PUT_ITEM_INPUT extends Record<string, any> = PutItemInput<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   putItemInput: Record<string, any>
-) => putItemInput is EntityPutItemInput
+) => putItemInput is PUT_ITEM_INPUT
 
 /**
  * Validate the input of a PUT command for a given Entity
@@ -17,12 +17,12 @@ type PutItemInputValidator = <
  * @return Boolean
  */
 export const validatePutItemInput: PutItemInputValidator = <
-  EntityInput extends EntityV2,
-  EntityPutItemInput extends Record<string, any> = PutItemInput<EntityInput>
+  ENTITY extends EntityV2,
+  PUT_ITEM_INPUT extends Record<string, any> = PutItemInput<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   putItemInput: Record<string, any>
-): putItemInput is EntityPutItemInput => {
+): putItemInput is PUT_ITEM_INPUT => {
   entity
   putItemInput
   // TODO

--- a/src/v1/entity/utils/validateSavedItem.ts
+++ b/src/v1/entity/utils/validateSavedItem.ts
@@ -2,12 +2,12 @@ import type { EntityV2 } from '../class'
 import type { SavedItem } from '../generics'
 
 type SavedItemValidator = <
-  EntityInput extends EntityV2,
-  EntitySavedItem extends Record<string, any> = SavedItem<EntityInput>
+  ENTITY extends EntityV2,
+  SAVED_ITEM extends Record<string, any> = SavedItem<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   savedItem: Record<string, any>
-) => savedItem is EntitySavedItem
+) => savedItem is SAVED_ITEM
 
 /**
  * Validates the saved item in DynamoDB for a given Entity
@@ -17,12 +17,12 @@ type SavedItemValidator = <
  * @return Boolean
  */
 export const validateSavedItem: SavedItemValidator = <
-  EntityInput extends EntityV2,
-  EntitySavedItem extends Record<string, any> = SavedItem<EntityInput>
+  ENTITY extends EntityV2,
+  SAVED_ITEM extends Record<string, any> = SavedItem<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   savedItem: Record<string, any>
-): savedItem is EntitySavedItem => {
+): savedItem is SAVED_ITEM => {
   entity
   savedItem
   // TODO

--- a/src/v1/entity/utils/validateUpdateItemInput.ts
+++ b/src/v1/entity/utils/validateUpdateItemInput.ts
@@ -2,12 +2,12 @@ import type { EntityV2 } from '../class'
 import type { UpdateItemInput } from '../generics'
 
 type UpdateItemInputValidator = <
-  EntityInput extends EntityV2,
-  EntityUpdateItem extends Record<string, any> = UpdateItemInput<EntityInput>
+  ENTITY extends EntityV2,
+  UPDATE_ITEM_INPUT extends Record<string, any> = UpdateItemInput<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   updateItemInput: Record<string, any>
-) => updateItemInput is EntityUpdateItem
+) => updateItemInput is UPDATE_ITEM_INPUT
 
 /**
  * Validate the input of an UPDATE command for a given Entity
@@ -17,12 +17,12 @@ type UpdateItemInputValidator = <
  * @return Boolean
  */
 export const validateUpdateItemInput: UpdateItemInputValidator = <
-  EntityInput extends EntityV2,
-  EntityUpdateItem extends Record<string, any> = UpdateItemInput<EntityInput>
+  ENTITY extends EntityV2,
+  UPDATE_ITEM_INPUT extends Record<string, any> = UpdateItemInput<ENTITY>
 >(
-  entity: EntityInput,
+  entity: ENTITY,
   updateItemInput: Record<string, any>
-): updateItemInput is EntityUpdateItem => {
+): updateItemInput is UPDATE_ITEM_INPUT => {
   entity
   updateItemInput
   // TODO

--- a/src/v1/item/attributes/any/freeze.ts
+++ b/src/v1/item/attributes/any/freeze.ts
@@ -2,10 +2,10 @@ import { validateAttributeProperties } from '../shared/validate'
 
 import type { _AnyAttribute, FreezeAnyAttribute } from './interface'
 
-type AnyAttributeFreezer = <Attribute extends _AnyAttribute>(
-  attribute: Attribute,
+type AnyAttributeFreezer = <_ANY_ATTRIBUTE extends _AnyAttribute>(
+  attribute: _ANY_ATTRIBUTE,
   path: string
-) => FreezeAnyAttribute<Attribute>
+) => FreezeAnyAttribute<_ANY_ATTRIBUTE>
 
 /**
  * Validates an any instance
@@ -14,10 +14,10 @@ type AnyAttributeFreezer = <Attribute extends _AnyAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeAnyAttribute: AnyAttributeFreezer = <Attribute extends _AnyAttribute>(
-  attribute: Attribute,
+export const freezeAnyAttribute: AnyAttributeFreezer = <_ANY_ATTRIBUTE extends _AnyAttribute>(
+  attribute: _ANY_ATTRIBUTE,
   path: string
-): FreezeAnyAttribute<Attribute> => {
+): FreezeAnyAttribute<_ANY_ATTRIBUTE> => {
   validateAttributeProperties(attribute, path)
 
   // TODO: validate that _default is valid ?

--- a/src/v1/item/attributes/any/interface.ts
+++ b/src/v1/item/attributes/any/interface.ts
@@ -7,14 +7,14 @@ import type { AnyAttributeDefaultValue } from './types'
  * Any attribute interface
  */
 export interface _AnyAttribute<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
-> extends _AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
+> extends _AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   _type: 'any'
-  _default: Default
+  _default: DEFAULT
   /**
    * Tag attribute as required. Possible values are:
    * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
@@ -24,49 +24,49 @@ export interface _AnyAttribute<
    *
    * @param nextRequired RequiredOption
    */
-  required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-    nextRequired?: NextIsRequired
-  ) => _AnyAttribute<NextIsRequired, IsHidden, IsKey, SavedAs, Default>
+  required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+    nextRequired?: NEXT_IS_REQUIRED
+  ) => _AnyAttribute<NEXT_IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => _AnyAttribute<IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _AnyAttribute<IS_REQUIRED, true, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => _AnyAttribute<IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _AnyAttribute<IS_REQUIRED, IS_HIDDEN, true, SAVED_AS, DEFAULT>
   /**
    * Rename attribute before save commands
    */
-  savedAs: <NextSavedAs extends string | undefined>(
-    nextSavedAs: NextSavedAs
-  ) => _AnyAttribute<IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  savedAs: <NEXT_SAVED_AS extends string | undefined>(
+    nextSavedAs: NEXT_SAVED_AS
+  ) => _AnyAttribute<IS_REQUIRED, IS_HIDDEN, IS_KEY, NEXT_SAVED_AS, DEFAULT>
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
    * @param nextDefaultValue `any`, `() => any`, `ComputedDefault`
    */
-  default: <NextDefaultValue extends AnyAttributeDefaultValue>(
-    nextDefaultValue: NextDefaultValue
-  ) => _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, NextDefaultValue>
+  default: <NEXT_DEFAULT_VALUE extends AnyAttributeDefaultValue>(
+    nextDefaultValue: NEXT_DEFAULT_VALUE
+  ) => _AnyAttribute<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, NEXT_DEFAULT_VALUE>
 }
 
 export interface AnyAttribute<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
-> extends AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
+> extends AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   type: 'any'
-  default: Default
+  default: DEFAULT
   path: string
 }
 
-export type FreezeAnyAttribute<Attribute extends _AnyAttribute> = AnyAttribute<
-  Attribute['_required'],
-  Attribute['_hidden'],
-  Attribute['_key'],
-  Attribute['_savedAs'],
-  Attribute['_default']
+export type FreezeAnyAttribute<_ANY_ATTRIBUTE extends _AnyAttribute> = AnyAttribute<
+  _ANY_ATTRIBUTE['_required'],
+  _ANY_ATTRIBUTE['_hidden'],
+  _ANY_ATTRIBUTE['_key'],
+  _ANY_ATTRIBUTE['_savedAs'],
+  _ANY_ATTRIBUTE['_default']
 >

--- a/src/v1/item/attributes/any/options.ts
+++ b/src/v1/item/attributes/any/options.ts
@@ -7,16 +7,16 @@ import type { AnyAttributeDefaultValue } from './types'
  * Input options of Any Attribute
  */
 export interface AnyAttributeOptions<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
-> extends AttributeOptions<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends AnyAttributeDefaultValue = AnyAttributeDefaultValue
+> extends AttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    */
-  default: Default
+  default: DEFAULT
 }
 
 export const ANY_DEFAULT_OPTIONS: AnyAttributeOptions<Never, false, false, undefined, undefined> = {

--- a/src/v1/item/attributes/any/typer.ts
+++ b/src/v1/item/attributes/any/typer.ts
@@ -7,14 +7,14 @@ import type { _AnyAttribute } from './interface'
 import { AnyAttributeOptions, ANY_DEFAULT_OPTIONS } from './options'
 
 type AnyAttributeTyper = <
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends AnyAttributeDefaultValue = undefined
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends AnyAttributeDefaultValue = undefined
 >(
-  options?: O.Partial<AnyAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
+  options?: O.Partial<AnyAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+) => _AnyAttribute<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 
 /**
  * Define a new attribute of any type
@@ -22,14 +22,14 @@ type AnyAttributeTyper = <
  * @param options _(optional)_ Boolean Options
  */
 export const any: AnyAttributeTyper = <
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends AnyAttributeDefaultValue = undefined
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends AnyAttributeDefaultValue = undefined
 >(
-  options?: O.Partial<AnyAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+  options?: O.Partial<AnyAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+): _AnyAttribute<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT> => {
   const appliedOptions = { ...ANY_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -46,12 +46,12 @@ export const any: AnyAttributeTyper = <
     _key,
     _savedAs,
     _default,
-    required: <NextRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired: NextRequired = ('atLeastOnce' as unknown) as NextRequired
+    required: <NEXT_REQUIRED extends RequiredOption = AtLeastOnce>(
+      nextRequired: NEXT_REQUIRED = ('atLeastOnce' as unknown) as NEXT_REQUIRED
     ) => any({ ...appliedOptions, required: nextRequired }),
     hidden: () => any({ ...appliedOptions, hidden: true }),
     key: () => any({ ...appliedOptions, key: true }),
     savedAs: nextSavedAs => any({ ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => any({ ...appliedOptions, default: nextDefault })
-  } as _AnyAttribute<IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _AnyAttribute<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 }

--- a/src/v1/item/attributes/freeze.ts
+++ b/src/v1/item/attributes/freeze.ts
@@ -5,20 +5,18 @@ import { freezeListAttribute, _ListAttribute, FreezeListAttribute } from './list
 import { freezeMapAttribute, _MapAttribute, FreezeMapAttribute } from './map'
 import type { _Attribute } from './types/attribute'
 
-export type FreezeAttribute<
-  AttributeInput extends _Attribute
-> = AttributeInput extends _AnyAttribute
-  ? FreezeAnyAttribute<AttributeInput>
-  : AttributeInput extends _LeafAttribute
-  ? FreezeLeafAttribute<AttributeInput>
-  : AttributeInput extends _SetAttribute
-  ? FreezeSetAttribute<AttributeInput>
-  : AttributeInput extends _ListAttribute
-  ? FreezeListAttribute<AttributeInput>
-  : AttributeInput extends _ListAttribute
-  ? FreezeListAttribute<AttributeInput>
-  : AttributeInput extends _MapAttribute
-  ? FreezeMapAttribute<AttributeInput>
+export type FreezeAttribute<_ATTRIBUTE extends _Attribute> = _ATTRIBUTE extends _AnyAttribute
+  ? FreezeAnyAttribute<_ATTRIBUTE>
+  : _ATTRIBUTE extends _LeafAttribute
+  ? FreezeLeafAttribute<_ATTRIBUTE>
+  : _ATTRIBUTE extends _SetAttribute
+  ? FreezeSetAttribute<_ATTRIBUTE>
+  : _ATTRIBUTE extends _ListAttribute
+  ? FreezeListAttribute<_ATTRIBUTE>
+  : _ATTRIBUTE extends _ListAttribute
+  ? FreezeListAttribute<_ATTRIBUTE>
+  : _ATTRIBUTE extends _MapAttribute
+  ? FreezeMapAttribute<_ATTRIBUTE>
   : never
 
 /**
@@ -28,10 +26,10 @@ export type FreezeAttribute<
  * @param path _(optional)_ Path of the attribute in the related item (string)
  * @return Attribute
  */
-export const freezeAttribute = <AttributeInput extends _Attribute>(
-  attribute: AttributeInput,
+export const freezeAttribute = <_ATTRIBUTE extends _Attribute>(
+  attribute: _ATTRIBUTE,
   path: string
-): FreezeAttribute<AttributeInput> => {
+): FreezeAttribute<_ATTRIBUTE> => {
   switch (attribute._type) {
     case 'boolean':
     case 'binary':

--- a/src/v1/item/attributes/leaf/freeze.ts
+++ b/src/v1/item/attributes/leaf/freeze.ts
@@ -7,10 +7,10 @@ import { validateAttributeProperties } from '../shared/validate'
 import type { _LeafAttribute, FreezeLeafAttribute } from './interface'
 import type { LeafAttributeType, LeafAttributeEnumValues, LeafAttributeDefaultValue } from './types'
 
-type LeafAttributeFreezer = <Attribute extends _LeafAttribute>(
-  attribute: Attribute,
+type LeafAttributeFreezer = <_LEAF_ATTRIBUTE extends _LeafAttribute>(
+  attribute: _LEAF_ATTRIBUTE,
   path: string
-) => FreezeLeafAttribute<Attribute>
+) => FreezeLeafAttribute<_LEAF_ATTRIBUTE>
 
 /**
  * Validates a leaf instance
@@ -19,10 +19,10 @@ type LeafAttributeFreezer = <Attribute extends _LeafAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeLeafAttribute: LeafAttributeFreezer = <Attribute extends _LeafAttribute>(
-  attribute: Attribute,
+export const freezeLeafAttribute: LeafAttributeFreezer = <_LEAF_ATTRIBUTE extends _LeafAttribute>(
+  attribute: _LEAF_ATTRIBUTE,
   path: string
-): FreezeLeafAttribute<Attribute> => {
+): FreezeLeafAttribute<_LEAF_ATTRIBUTE> => {
   validateAttributeProperties(attribute, path)
 
   const { _type: leafType, _enum: enumValues, _default: defaultValue, ...leafInstance } = attribute
@@ -59,10 +59,13 @@ export const freezeLeafAttribute: LeafAttributeFreezer = <Attribute extends _Lea
     hidden,
     key,
     savedAs,
-    enum: enumValues as Extract<Attribute['_enum'], LeafAttributeEnumValues<Attribute['_type']>>,
+    enum: enumValues as Extract<
+      _LEAF_ATTRIBUTE['_enum'],
+      LeafAttributeEnumValues<_LEAF_ATTRIBUTE['_type']>
+    >,
     default: defaultValue as Extract<
-      Attribute['_default'],
-      LeafAttributeDefaultValue<Attribute['_type']>
+      _LEAF_ATTRIBUTE['_default'],
+      LeafAttributeDefaultValue<_LEAF_ATTRIBUTE['_type']>
     >
   }
 }

--- a/src/v1/item/attributes/leaf/interface.ts
+++ b/src/v1/item/attributes/leaf/interface.ts
@@ -12,20 +12,20 @@ import type {
  * Leaf attribute interface
  */
 export type _LeafAttribute<
-  Type extends LeafAttributeType = LeafAttributeType,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Enum extends LeafAttributeEnumValues<Type> = LeafAttributeEnumValues<Type>,
-  Default extends LeafAttributeDefaultValue<Type> = LeafAttributeDefaultValue<Type>
-> = _AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> & {
-  _type: Type
-  _resolved?: Enum extends ResolveLeafAttributeType<Type>[]
-    ? Enum[number]
-    : ResolveLeafAttributeType<Type>
-  _enum: Enum
-  _default: Default
+  TYPE extends LeafAttributeType = LeafAttributeType,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  ENUM extends LeafAttributeEnumValues<TYPE> = LeafAttributeEnumValues<TYPE>,
+  DEFAULT extends LeafAttributeDefaultValue<TYPE> = LeafAttributeDefaultValue<TYPE>
+> = _AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> & {
+  _type: TYPE
+  _resolved?: ENUM extends ResolveLeafAttributeType<TYPE>[]
+    ? ENUM[number]
+    : ResolveLeafAttributeType<TYPE>
+  _enum: ENUM
+  _default: DEFAULT
   /**
    * Tag attribute as required. Possible values are:
    * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
@@ -35,23 +35,23 @@ export type _LeafAttribute<
    *
    * @param nextRequired RequiredOption
    */
-  required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-    nextRequired?: NextIsRequired
-  ) => _LeafAttribute<Type, NextIsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+  required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+    nextRequired?: NEXT_IS_REQUIRED
+  ) => _LeafAttribute<TYPE, NEXT_IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, DEFAULT>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => _LeafAttribute<Type, IsRequired, true, IsKey, SavedAs, Enum, Default>
+  hidden: () => _LeafAttribute<TYPE, IS_REQUIRED, true, IS_KEY, SAVED_AS, ENUM, DEFAULT>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => _LeafAttribute<Type, IsRequired, IsHidden, true, SavedAs, Enum, Default>
+  key: () => _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, true, SAVED_AS, ENUM, DEFAULT>
   /**
    * Rename attribute before save commands
    */
-  savedAs: <NextSavedAs extends string | undefined>(
-    nextSavedAs: NextSavedAs
-  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, NextSavedAs, Enum, Default>
+  savedAs: <NEXT_SAVED_AS extends string | undefined>(
+    nextSavedAs: NEXT_SAVED_AS
+  ) => _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, NEXT_SAVED_AS, ENUM, DEFAULT>
   /**
    * Provide a finite list of possible values for attribute
    * (For typing reasons, enums are only available as attribute methods, not as input options)
@@ -60,48 +60,56 @@ export type _LeafAttribute<
    * @example
    * string().enum('foo', 'bar')
    */
-  enum: <NextEnum extends ResolveLeafAttributeType<Type>[]>(
-    ...nextEnum: NextEnum
-  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, NextEnum, Default & NextEnum>
+  enum: <NEXT_ENUM extends ResolveLeafAttributeType<TYPE>[]>(
+    ...nextEnum: NEXT_ENUM
+  ) => _LeafAttribute<
+    TYPE,
+    IS_REQUIRED,
+    IS_HIDDEN,
+    IS_KEY,
+    SAVED_AS,
+    NEXT_ENUM,
+    DEFAULT & NEXT_ENUM
+  >
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
    * @param nextDefaultValue `Attribute type`, `() => Attribute type`, `ComputedDefault`
    */
   default: <
-    NextDefault extends LeafAttributeDefaultValue<Type> &
-      (Enum extends ResolveLeafAttributeType<Type>[]
-        ? Enum[number] | (() => Enum[number])
+    NEXT_DEFAULT extends LeafAttributeDefaultValue<TYPE> &
+      (ENUM extends ResolveLeafAttributeType<TYPE>[]
+        ? ENUM[number] | (() => ENUM[number])
         : unknown)
   >(
-    nextDefaultValue: NextDefault
-  ) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, NextDefault>
+    nextDefaultValue: NEXT_DEFAULT
+  ) => _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, NEXT_DEFAULT>
 }
 
 export type LeafAttribute<
-  Type extends LeafAttributeType = LeafAttributeType,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Enum extends LeafAttributeEnumValues<Type> = LeafAttributeEnumValues<Type>,
-  Default extends LeafAttributeDefaultValue<Type> = LeafAttributeDefaultValue<Type>
-> = AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> & {
+  TYPE extends LeafAttributeType = LeafAttributeType,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  ENUM extends LeafAttributeEnumValues<TYPE> = LeafAttributeEnumValues<TYPE>,
+  DEFAULT extends LeafAttributeDefaultValue<TYPE> = LeafAttributeDefaultValue<TYPE>
+> = AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> & {
   path: string
-  type: Type
-  resolved?: Enum extends ResolveLeafAttributeType<Type>[]
-    ? Enum[number]
-    : ResolveLeafAttributeType<Type>
-  enum: Enum
-  default: Default
+  type: TYPE
+  resolved?: ENUM extends ResolveLeafAttributeType<TYPE>[]
+    ? ENUM[number]
+    : ResolveLeafAttributeType<TYPE>
+  enum: ENUM
+  default: DEFAULT
 }
 
-export type FreezeLeafAttribute<Attribute extends _LeafAttribute> = LeafAttribute<
-  Attribute['_type'],
-  Attribute['_required'],
-  Attribute['_hidden'],
-  Attribute['_key'],
-  Attribute['_savedAs'],
-  Extract<Attribute['_enum'], LeafAttributeEnumValues<Attribute['_type']>>,
-  Extract<Attribute['_default'], LeafAttributeDefaultValue<Attribute['_type']>>
+export type FreezeLeafAttribute<_LEAF_ATTRIBUTE extends _LeafAttribute> = LeafAttribute<
+  _LEAF_ATTRIBUTE['_type'],
+  _LEAF_ATTRIBUTE['_required'],
+  _LEAF_ATTRIBUTE['_hidden'],
+  _LEAF_ATTRIBUTE['_key'],
+  _LEAF_ATTRIBUTE['_savedAs'],
+  Extract<_LEAF_ATTRIBUTE['_enum'], LeafAttributeEnumValues<_LEAF_ATTRIBUTE['_type']>>,
+  Extract<_LEAF_ATTRIBUTE['_default'], LeafAttributeDefaultValue<_LEAF_ATTRIBUTE['_type']>>
 >

--- a/src/v1/item/attributes/leaf/options.ts
+++ b/src/v1/item/attributes/leaf/options.ts
@@ -7,19 +7,19 @@ import type { LeafAttributeType, LeafAttributeEnumValues, LeafAttributeDefaultVa
  * Input options of Leaf Attribute
  */
 export interface LeafAttributeOptions<
-  Type extends LeafAttributeType = LeafAttributeType,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Enum extends LeafAttributeEnumValues<Type> = LeafAttributeEnumValues<Type>,
-  Default extends LeafAttributeDefaultValue<Type> = LeafAttributeDefaultValue<Type>
-> extends AttributeOptions<IsRequired, IsHidden, IsKey, SavedAs> {
-  _enum: Enum
+  TYPE extends LeafAttributeType = LeafAttributeType,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  ENUM extends LeafAttributeEnumValues<TYPE> = LeafAttributeEnumValues<TYPE>,
+  DEFAULT extends LeafAttributeDefaultValue<TYPE> = LeafAttributeDefaultValue<TYPE>
+> extends AttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
+  _enum: ENUM
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    */
-  default: Default
+  default: DEFAULT
 }
 
 export const LEAF_DEFAULT_OPTIONS: LeafAttributeOptions<

--- a/src/v1/item/attributes/leaf/typer.ts
+++ b/src/v1/item/attributes/leaf/typer.ts
@@ -12,24 +12,24 @@ import type { LeafAttributeType, LeafAttributeEnumValues, LeafAttributeDefaultVa
  * @param options _(optional)_ Leaf Options
  */
 const leaf = <
-  Type extends LeafAttributeType = LeafAttributeType,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Enum extends LeafAttributeEnumValues<Type> = LeafAttributeEnumValues<Type>,
-  Default extends LeafAttributeDefaultValue<Type> = LeafAttributeDefaultValue<Type>
+  TYPE extends LeafAttributeType = LeafAttributeType,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  ENUM extends LeafAttributeEnumValues<TYPE> = LeafAttributeEnumValues<TYPE>,
+  DEFAULT extends LeafAttributeDefaultValue<TYPE> = LeafAttributeDefaultValue<TYPE>
 >(
-  options: { type: Type } & LeafAttributeOptions<
-    Type,
-    IsRequired,
-    IsHidden,
-    IsKey,
-    SavedAs,
-    Enum,
-    Default
+  options: { type: TYPE } & LeafAttributeOptions<
+    TYPE,
+    IS_REQUIRED,
+    IS_HIDDEN,
+    IS_KEY,
+    SAVED_AS,
+    ENUM,
+    DEFAULT
   >
-): _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default> => {
+): _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, DEFAULT> => {
   const {
     type: _type,
     required: _required,
@@ -48,43 +48,43 @@ const leaf = <
     _savedAs,
     _default,
     _enum,
-    required: <NextRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired = 'atLeastOnce' as NextRequired
+    required: <NEXT_REQUIRED extends RequiredOption = AtLeastOnce>(
+      nextRequired = 'atLeastOnce' as NEXT_REQUIRED
     ) => leaf({ ...options, required: nextRequired }),
     hidden: () => leaf({ ...options, hidden: true }),
     key: () => leaf({ ...options, key: true }),
     savedAs: nextSavedAs => leaf({ ...options, savedAs: nextSavedAs }),
     default: nextDefault => leaf({ ...options, default: nextDefault }),
     enum: (...nextEnum) => leaf({ ...options, _enum: nextEnum })
-  } as _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+  } as _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, DEFAULT>
 }
 
-type LeafAttributeTyper<Type extends LeafAttributeType> = <
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Enum extends LeafAttributeEnumValues<Type> = undefined,
-  Default extends LeafAttributeDefaultValue<Type> = undefined
+type LeafAttributeTyper<TYPE extends LeafAttributeType> = <
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  ENUM extends LeafAttributeEnumValues<TYPE> = undefined,
+  DEFAULT extends LeafAttributeDefaultValue<TYPE> = undefined
 >(
   options?: O.Partial<
-    LeafAttributeOptions<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+    LeafAttributeOptions<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, DEFAULT>
   >
-) => _LeafAttribute<Type, IsRequired, IsHidden, IsKey, SavedAs, Enum, Default>
+) => _LeafAttribute<TYPE, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, ENUM, DEFAULT>
 
-const getLeafAttributeTyper = <Type extends LeafAttributeType>(type: Type) =>
+const getLeafAttributeTyper = <TYPE extends LeafAttributeType>(type: TYPE) =>
   (<
-    Required extends RequiredOption = Never,
-    Hidden extends boolean = false,
-    Key extends boolean = false,
-    SavedAs extends string | undefined = undefined,
-    Enum extends LeafAttributeEnumValues<Type> = undefined,
-    Default extends LeafAttributeDefaultValue<Type> = undefined
+    REQUIRED extends RequiredOption = Never,
+    HIDDEN extends boolean = false,
+    KEY extends boolean = false,
+    SAVED_AS extends string | undefined = undefined,
+    ENUM extends LeafAttributeEnumValues<TYPE> = undefined,
+    DEFAULT extends LeafAttributeDefaultValue<TYPE> = undefined
   >(
     leafOptions?: O.Partial<
-      LeafAttributeOptions<Type, Required, Hidden, Key, SavedAs, Enum, Default>
+      LeafAttributeOptions<TYPE, REQUIRED, HIDDEN, KEY, SAVED_AS, ENUM, DEFAULT>
     >
-  ) => leaf({ ...LEAF_DEFAULT_OPTIONS, ...leafOptions, type })) as LeafAttributeTyper<Type>
+  ) => leaf({ ...LEAF_DEFAULT_OPTIONS, ...leafOptions, type })) as LeafAttributeTyper<TYPE>
 
 /**
  * Define a new string attribute

--- a/src/v1/item/attributes/leaf/types.ts
+++ b/src/v1/item/attributes/leaf/types.ts
@@ -10,13 +10,13 @@ export type LeafAttributeType = 'string' | 'boolean' | 'number' | 'binary'
  *
  * @param T Leaf Type
  */
-export type ResolveLeafAttributeType<Type extends LeafAttributeType> = Type extends 'string'
+export type ResolveLeafAttributeType<TYPE extends LeafAttributeType> = TYPE extends 'string'
   ? string
-  : Type extends 'number'
+  : TYPE extends 'number'
   ? number
-  : Type extends 'boolean'
+  : TYPE extends 'boolean'
   ? boolean
-  : Type extends 'binary'
+  : TYPE extends 'binary'
   ? Buffer
   : never
 
@@ -28,15 +28,15 @@ export type ResolvedLeafAttributeType = ResolveLeafAttributeType<LeafAttributeTy
 /**
  * Leaf Enum values constraint
  */
-export type LeafAttributeEnumValues<Type extends LeafAttributeType> =
-  | ResolveLeafAttributeType<Type>[]
+export type LeafAttributeEnumValues<TYPE extends LeafAttributeType> =
+  | ResolveLeafAttributeType<TYPE>[]
   | undefined
 
 /**
  * Leaf Default values constraint
  */
-export type LeafAttributeDefaultValue<Type extends LeafAttributeType> =
+export type LeafAttributeDefaultValue<TYPE extends LeafAttributeType> =
   | undefined
   | ComputedDefault
-  | ResolveLeafAttributeType<Type>
-  | (() => ResolveLeafAttributeType<Type>)
+  | ResolveLeafAttributeType<TYPE>
+  | (() => ResolveLeafAttributeType<TYPE>)

--- a/src/v1/item/attributes/list/freeze.ts
+++ b/src/v1/item/attributes/list/freeze.ts
@@ -3,10 +3,10 @@ import { freezeAttribute } from '../freeze'
 
 import type { _ListAttribute, FreezeListAttribute } from './interface'
 
-type ListAttributeFreezer = <Attribute extends _ListAttribute>(
-  attribute: Attribute,
+type ListAttributeFreezer = <_LIST_ATTRIBUTE extends _ListAttribute>(
+  attribute: _LIST_ATTRIBUTE,
   path: string
-) => FreezeListAttribute<Attribute>
+) => FreezeListAttribute<_LIST_ATTRIBUTE>
 
 /**
  * Freezes a list instance
@@ -15,10 +15,10 @@ type ListAttributeFreezer = <Attribute extends _ListAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeListAttribute: ListAttributeFreezer = <Attribute extends _ListAttribute>(
-  attribute: Attribute,
+export const freezeListAttribute: ListAttributeFreezer = <_LIST_ATTRIBUTE extends _ListAttribute>(
+  attribute: _LIST_ATTRIBUTE,
   path: string
-): FreezeListAttribute<Attribute> => {
+): FreezeListAttribute<_LIST_ATTRIBUTE> => {
   validateAttributeProperties(attribute, path)
 
   const {
@@ -30,7 +30,7 @@ export const freezeListAttribute: ListAttributeFreezer = <Attribute extends _Lis
     _default
   } = attribute
 
-  const elements: Attribute['_elements'] = attribute._elements
+  const elements: _LIST_ATTRIBUTE['_elements'] = attribute._elements
   const {
     _required: elementsRequired,
     _hidden: elementsHidden,

--- a/src/v1/item/attributes/list/interface.ts
+++ b/src/v1/item/attributes/list/interface.ts
@@ -8,16 +8,16 @@ import type { _ListAttributeElements, ListAttributeElements } from './types'
  * List attribute interface
  */
 export interface _ListAttribute<
-  Elements extends _ListAttributeElements = _ListAttributeElements,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends _AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  ELEMENTS extends _ListAttributeElements = _ListAttributeElements,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends _AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   _type: 'list'
-  _elements: Elements
-  _default: Default
+  _elements: ELEMENTS
+  _default: DEFAULT
   /**
    * Tag attribute as required. Possible values are:
    * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
@@ -27,52 +27,52 @@ export interface _ListAttribute<
    *
    * @param nextRequired RequiredOption
    */
-  required: <NextRequired extends RequiredOption = AtLeastOnce>(
-    nextRequired?: NextRequired
-  ) => _ListAttribute<Elements, NextRequired, IsHidden, IsKey, SavedAs, Default>
+  required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+    nextRequired?: NEXT_IS_REQUIRED
+  ) => _ListAttribute<ELEMENTS, NEXT_IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => _ListAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _ListAttribute<ELEMENTS, IS_REQUIRED, true, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => _ListAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, true, SAVED_AS, DEFAULT>
   /**
    * Rename attribute before save commands
    */
-  savedAs: <NextSavedAs extends string | undefined>(
-    nextSavedAs: NextSavedAs
-  ) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  savedAs: <NEXT_SAVED_AS extends string | undefined>(
+    nextSavedAs: NEXT_SAVED_AS
+  ) => _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, NEXT_SAVED_AS, DEFAULT>
   /**
    * Tag attribute as having a computed default value
    *
    * @param nextDefaultValue `ComputedDefault`
    */
-  default: <NextDefault extends ComputedDefault | undefined>(
-    nextDefaultValue: NextDefault
-  ) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
+  default: <NEXT_DEFAULT extends ComputedDefault | undefined>(
+    nextDefaultValue: NEXT_DEFAULT
+  ) => _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, NEXT_DEFAULT>
 }
 
 export interface ListAttribute<
-  Elements extends ListAttributeElements = ListAttributeElements,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  ELEMENTS extends ListAttributeElements = ListAttributeElements,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   type: 'list'
-  elements: Elements
-  default: Default
+  elements: ELEMENTS
+  default: DEFAULT
   path: string
 }
 
-export type FreezeListAttribute<Attribute extends _ListAttribute> = ListAttribute<
-  FreezeAttribute<Attribute['_elements']>,
-  Attribute['_required'],
-  Attribute['_hidden'],
-  Attribute['_key'],
-  Attribute['_savedAs'],
-  Attribute['_default']
+export type FreezeListAttribute<_LIST_ATTRIBUTE extends _ListAttribute> = ListAttribute<
+  FreezeAttribute<_LIST_ATTRIBUTE['_elements']>,
+  _LIST_ATTRIBUTE['_required'],
+  _LIST_ATTRIBUTE['_hidden'],
+  _LIST_ATTRIBUTE['_key'],
+  _LIST_ATTRIBUTE['_savedAs'],
+  _LIST_ATTRIBUTE['_default']
 >

--- a/src/v1/item/attributes/list/options.ts
+++ b/src/v1/item/attributes/list/options.ts
@@ -5,23 +5,28 @@ import { ComputedDefault, RequiredOption, Never } from '../constants'
  * Input options of List Attribute
  */
 export interface ListAttributeOptions<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends AttributeOptions<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends AttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   /**
    * Tag attribute as having a computed default value
    */
-  default: Default
+  default: DEFAULT
 }
 
-export const LIST_DEFAULT_OPTIONS: ListAttributeOptions<Never, false, false, undefined, undefined> =
-  {
-    required: 'never',
-    hidden: false,
-    key: false,
-    savedAs: undefined,
-    default: undefined
-  }
+export const LIST_DEFAULT_OPTIONS: ListAttributeOptions<
+  Never,
+  false,
+  false,
+  undefined,
+  undefined
+> = {
+  required: 'never',
+  hidden: false,
+  key: false,
+  savedAs: undefined,
+  default: undefined
+}

--- a/src/v1/item/attributes/list/typer.ts
+++ b/src/v1/item/attributes/list/typer.ts
@@ -7,16 +7,16 @@ import type { _ListAttribute } from './interface'
 import { ListAttributeOptions, LIST_DEFAULT_OPTIONS } from './options'
 
 type ListTyper = <
-  Elements extends _ListAttributeElements,
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ELEMENTS extends _ListAttributeElements,
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  _elements: Elements,
-  options?: O.Partial<ListAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  _elements: ELEMENTS,
+  options?: O.Partial<ListAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+) => _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 
 /**
  * Define a new list attribute
@@ -30,16 +30,16 @@ type ListTyper = <
  * @param options _(optional)_ List Options
  */
 export const list: ListTyper = <
-  Elements extends _ListAttributeElements,
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ELEMENTS extends _ListAttributeElements,
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  elements: Elements,
-  options?: O.Partial<ListAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+  elements: ELEMENTS,
+  options?: O.Partial<ListAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+): _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT> => {
   const appliedOptions = { ...LIST_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -57,12 +57,12 @@ export const list: ListTyper = <
     _key,
     _savedAs,
     _default,
-    required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired: NextIsRequired = 'atLeastOnce' as NextIsRequired
+    required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+      nextRequired: NEXT_IS_REQUIRED = 'atLeastOnce' as NEXT_IS_REQUIRED
     ) => list(elements, { ...appliedOptions, required: nextRequired }),
     hidden: () => list(elements, { ...appliedOptions, hidden: true }),
     key: () => list(elements, { ...appliedOptions, key: true }),
     savedAs: nextSavedAs => list(elements, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => list(elements, { ...appliedOptions, default: nextDefault })
-  } as _ListAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _ListAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 }

--- a/src/v1/item/attributes/map/freeze.ts
+++ b/src/v1/item/attributes/map/freeze.ts
@@ -4,10 +4,10 @@ import { freezeAttribute, FreezeAttribute } from '../freeze'
 
 import type { _MapAttribute, FreezeMapAttribute } from './interface'
 
-type MapAttributeFreezer = <Attribute extends _MapAttribute>(
-  attribute: Attribute,
+type MapAttributeFreezer = <_MAP_ATTRIBUTE extends _MapAttribute>(
+  attribute: _MAP_ATTRIBUTE,
   path: string
-) => FreezeMapAttribute<Attribute>
+) => FreezeMapAttribute<_MAP_ATTRIBUTE>
 
 /**
  * Freezes a map instance
@@ -16,10 +16,10 @@ type MapAttributeFreezer = <Attribute extends _MapAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeMapAttribute: MapAttributeFreezer = <Attribute extends _MapAttribute>(
-  attribute: Attribute,
+export const freezeMapAttribute: MapAttributeFreezer = <_MAP_ATTRIBUTE extends _MapAttribute>(
+  attribute: _MAP_ATTRIBUTE,
   path: string
-): FreezeMapAttribute<Attribute> => {
+): FreezeMapAttribute<_MAP_ATTRIBUTE> => {
   validateAttributeProperties(attribute, path)
 
   const {
@@ -41,9 +41,11 @@ export const freezeMapAttribute: MapAttributeFreezer = <Attribute extends _MapAt
     never: new Set()
   }
 
-  const attributes: Attribute['_attributes'] = attribute._attributes
+  const attributes: _MAP_ATTRIBUTE['_attributes'] = attribute._attributes
   const frozenAttributes: {
-    [key in keyof Attribute['_attributes']]: FreezeAttribute<Attribute['_attributes'][key]>
+    [key in keyof _MAP_ATTRIBUTE['_attributes']]: FreezeAttribute<
+      _MAP_ATTRIBUTE['_attributes'][key]
+    >
   } = {} as any
 
   for (const attributeName in attributes) {

--- a/src/v1/item/attributes/map/interface.ts
+++ b/src/v1/item/attributes/map/interface.ts
@@ -9,18 +9,18 @@ import type { FreezeAttribute } from '../freeze'
  * (Called MapAttribute to differ from native TS Map class)
  */
 export interface _MapAttribute<
-  Attributes extends _MapAttributeAttributes = _MapAttributeAttributes,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  IsOpen extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends _AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  ATTRIBUTES extends _MapAttributeAttributes = _MapAttributeAttributes,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  IS_OPEN extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends _AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   _type: 'map'
-  _attributes: Attributes
-  _open: IsOpen
-  _default: Default
+  _attributes: ATTRIBUTES
+  _open: IS_OPEN
+  _default: DEFAULT
   /**
    * Tag attribute as required. Possible values are:
    * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
@@ -30,64 +30,66 @@ export interface _MapAttribute<
    *
    * @param nextRequired RequiredOption
    */
-  required: <NextRequired extends RequiredOption = AtLeastOnce>(
-    nextRequired?: NextRequired
-  ) => _MapAttribute<Attributes, NextRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+  required: <NEXT_REQUIRED extends RequiredOption = AtLeastOnce>(
+    nextRequired?: NEXT_REQUIRED
+  ) => _MapAttribute<ATTRIBUTES, NEXT_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => _MapAttribute<Attributes, IsRequired, true, IsKey, IsOpen, SavedAs, Default>
+  hidden: () => _MapAttribute<ATTRIBUTES, IS_REQUIRED, true, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => _MapAttribute<Attributes, IsRequired, IsHidden, true, IsOpen, SavedAs, Default>
+  key: () => _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, true, IS_OPEN, SAVED_AS, DEFAULT>
   /**
    * Accept additional attributes of any type
    */
-  open: () => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, true, SavedAs, Default>
+  open: () => _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, true, SAVED_AS, DEFAULT>
   /**
    * Rename attribute before save commands
    */
-  savedAs: <NextSavedAs extends string | undefined>(
-    nextSavedAs: NextSavedAs
-  ) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, NextSavedAs, Default>
+  savedAs: <NEXT_SAVED_AS extends string | undefined>(
+    nextSavedAs: NEXT_SAVED_AS
+  ) => _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, NEXT_SAVED_AS, DEFAULT>
   /**
    * Tag attribute as having a computed default value
    *
    * @param nextDefaultValue `ComputedDefault`
    */
-  default: <NextComputeDefault extends ComputedDefault | undefined>(
-    nextDefaultValue: NextComputeDefault
-  ) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, NextComputeDefault>
+  default: <NEXT_DEFAULT extends ComputedDefault | undefined>(
+    nextDefaultValue: NEXT_DEFAULT
+  ) => _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, NEXT_DEFAULT>
 }
 
 export interface MapAttribute<
-  Attributes extends MapAttributeAttributes = MapAttributeAttributes,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  IsOpen extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> {
+  ATTRIBUTES extends MapAttributeAttributes = MapAttributeAttributes,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  IS_OPEN extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   type: 'map'
-  attributes: Attributes
-  open: IsOpen
-  default: Default
+  attributes: ATTRIBUTES
+  open: IS_OPEN
+  default: DEFAULT
   path: string
   requiredAttributesNames: Record<RequiredOption, Set<string>>
 }
 
-export type FreezeMapAttribute<Attribute extends _MapAttribute> = MapAttribute<
-  _MapAttribute extends Attribute
+export type FreezeMapAttribute<_MAP_ATTRIBUTE extends _MapAttribute> = MapAttribute<
+  _MapAttribute extends _MAP_ATTRIBUTE
     ? MapAttributeAttributes
     : {
-        [key in keyof Attribute['_attributes']]: FreezeAttribute<Attribute['_attributes'][key]>
+        [key in keyof _MAP_ATTRIBUTE['_attributes']]: FreezeAttribute<
+          _MAP_ATTRIBUTE['_attributes'][key]
+        >
       },
-  Attribute['_required'],
-  Attribute['_hidden'],
-  Attribute['_key'],
-  Attribute['_open'],
-  Attribute['_savedAs'],
-  Attribute['_default']
+  _MAP_ATTRIBUTE['_required'],
+  _MAP_ATTRIBUTE['_hidden'],
+  _MAP_ATTRIBUTE['_key'],
+  _MAP_ATTRIBUTE['_open'],
+  _MAP_ATTRIBUTE['_savedAs'],
+  _MAP_ATTRIBUTE['_default']
 >

--- a/src/v1/item/attributes/map/options.ts
+++ b/src/v1/item/attributes/map/options.ts
@@ -5,21 +5,21 @@ import { ComputedDefault, RequiredOption, Never } from '../constants'
  * Input options of MapAttribute Attribute
  */
 export interface MapAttributeOptions<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  IsOpen extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends AttributeOptions<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  IS_OPEN extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends AttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   /**
    * Accept additional attributes of any type
    */
-  open: IsOpen
+  open: IS_OPEN
   /**
    * Tag attribute as having a computed default value
    */
-  default: Default
+  default: DEFAULT
 }
 
 export const MAPPED_DEFAULT_OPTIONS: MapAttributeOptions<

--- a/src/v1/item/attributes/map/typer.ts
+++ b/src/v1/item/attributes/map/typer.ts
@@ -7,17 +7,19 @@ import type { _MapAttribute } from './interface'
 import { MapAttributeOptions, MAPPED_DEFAULT_OPTIONS } from './options'
 
 type MapAttributeAttributeTyper = <
-  Attributes extends _MapAttributeAttributes = {},
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  IsOpen extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ATTRIBUTES extends _MapAttributeAttributes = {},
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  IS_OPEN extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  _attributes: Narrow<Attributes>,
-  options?: O.Partial<MapAttributeOptions<IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>>
-) => _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+  _attributes: Narrow<ATTRIBUTES>,
+  options?: O.Partial<
+    MapAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
+  >
+) => _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
 
 /**
  * Define a new map attribute
@@ -26,17 +28,19 @@ type MapAttributeAttributeTyper = <
  * @param options _(optional)_ Map Options
  */
 export const map: MapAttributeAttributeTyper = <
-  Attributes extends _MapAttributeAttributes = {},
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  IsOpen extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ATTRIBUTES extends _MapAttributeAttributes = {},
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  IS_OPEN extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  attributes: Narrow<Attributes>,
-  options?: O.Partial<MapAttributeOptions<IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>>
-): _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default> => {
+  attributes: Narrow<ATTRIBUTES>,
+  options?: O.Partial<
+    MapAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
+  >
+): _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT> => {
   const appliedOptions = { ...MAPPED_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -56,13 +60,13 @@ export const map: MapAttributeAttributeTyper = <
     _open,
     _savedAs,
     _default,
-    required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired: NextIsRequired = ('atLeastOnce' as unknown) as NextIsRequired
+    required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+      nextRequired: NEXT_IS_REQUIRED = ('atLeastOnce' as unknown) as NEXT_IS_REQUIRED
     ) => map(attributes, { ...appliedOptions, required: nextRequired }),
     hidden: () => map(attributes, { ...appliedOptions, hidden: true }),
     key: () => map(attributes, { ...appliedOptions, key: true }),
     open: () => map(attributes, { ...appliedOptions, open: true }),
     savedAs: nextSavedAs => map(attributes, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => map(attributes, { ...appliedOptions, default: nextDefault })
-  } as _MapAttribute<Attributes, IsRequired, IsHidden, IsKey, IsOpen, SavedAs, Default>
+  } as _MapAttribute<ATTRIBUTES, IS_REQUIRED, IS_HIDDEN, IS_KEY, IS_OPEN, SAVED_AS, DEFAULT>
 }

--- a/src/v1/item/attributes/set/freeze.ts
+++ b/src/v1/item/attributes/set/freeze.ts
@@ -3,10 +3,10 @@ import { freezeAttribute } from '../freeze'
 
 import { _SetAttribute, FreezeSetAttribute } from './interface'
 
-type SetAttributeFreezer = <Attribute extends _SetAttribute>(
-  attribute: Attribute,
+type SetAttributeFreezer = <_SET_ATTRIBUTE extends _SetAttribute>(
+  attribute: _SET_ATTRIBUTE,
   path: string
-) => FreezeSetAttribute<Attribute>
+) => FreezeSetAttribute<_SET_ATTRIBUTE>
 
 /**
  * Validates a set instance
@@ -15,10 +15,10 @@ type SetAttributeFreezer = <Attribute extends _SetAttribute>(
  * @param path _(optional)_ Path of the instance in the related item (string)
  * @return void
  */
-export const freezeSetAttribute: SetAttributeFreezer = <Attribute extends _SetAttribute>(
-  attribute: Attribute,
+export const freezeSetAttribute: SetAttributeFreezer = <_SET_ATTRIBUTE extends _SetAttribute>(
+  attribute: _SET_ATTRIBUTE,
   path: string
-): FreezeSetAttribute<Attribute> => {
+): FreezeSetAttribute<_SET_ATTRIBUTE> => {
   validateAttributeProperties(attribute, path)
 
   const {
@@ -30,7 +30,7 @@ export const freezeSetAttribute: SetAttributeFreezer = <Attribute extends _SetAt
     _default
   } = attribute
 
-  const elements: Attribute['_elements'] = attribute._elements
+  const elements: _SET_ATTRIBUTE['_elements'] = attribute._elements
   const {
     _required: elementsRequired,
     _hidden: elementsHidden,

--- a/src/v1/item/attributes/set/interface.ts
+++ b/src/v1/item/attributes/set/interface.ts
@@ -8,16 +8,16 @@ import type { _SetAttributeElements, SetAttributeElements } from './types'
  * Set attribute interface
  */
 export type _SetAttribute<
-  Elements extends _SetAttributeElements = _SetAttributeElements,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> = _AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> & {
+  ELEMENTS extends _SetAttributeElements = _SetAttributeElements,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> = _AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> & {
   _type: 'set'
-  _elements: Elements
-  _default: Default
+  _elements: ELEMENTS
+  _default: DEFAULT
   /**
    * Tag attribute as required. Possible values are:
    * - `"atLeastOnce"` _(default)_: Required in PUTs, optional in UPDATEs
@@ -27,52 +27,52 @@ export type _SetAttribute<
    *
    * @param nextRequired RequiredOption
    */
-  required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-    nextRequired?: NextIsRequired
-  ) => _SetAttribute<Elements, NextIsRequired, IsHidden, IsKey, SavedAs, Default>
+  required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+    nextRequired?: NEXT_IS_REQUIRED
+  ) => _SetAttribute<ELEMENTS, NEXT_IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: () => _SetAttribute<Elements, IsRequired, true, IsKey, SavedAs, Default>
+  hidden: () => _SetAttribute<ELEMENTS, IS_REQUIRED, true, IS_KEY, SAVED_AS, DEFAULT>
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: () => _SetAttribute<Elements, IsRequired, IsHidden, true, SavedAs, Default>
+  key: () => _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, true, SAVED_AS, DEFAULT>
   /**
    * Rename attribute before save commands
    */
-  savedAs: <NextSavedAs extends string | undefined>(
-    nextSavedAs: NextSavedAs
-  ) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, NextSavedAs, Default>
+  savedAs: <NEXT_SAVED_AS extends string | undefined>(
+    nextSavedAs: NEXT_SAVED_AS
+  ) => _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, NEXT_SAVED_AS, DEFAULT>
   /**
    * Provide a default value for attribute, or tag attribute as having a computed default value
    *
    * @param nextDefaultValue `Attribute type`, `() => Attribute type`, `ComputedDefault`
    */
-  default: <NextDefault extends ComputedDefault | undefined>(
-    nextDefaultValue: NextDefault
-  ) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, NextDefault>
+  default: <NEXT_DEFAULT extends ComputedDefault | undefined>(
+    nextDefaultValue: NEXT_DEFAULT
+  ) => _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, NEXT_DEFAULT>
 }
 
 export type SetAttribute<
-  Elements extends SetAttributeElements = SetAttributeElements,
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> = AttributeProperties<IsRequired, IsHidden, IsKey, SavedAs> & {
+  ELEMENTS extends SetAttributeElements = SetAttributeElements,
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> = AttributeProperties<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> & {
   type: 'set'
   path: string
-  elements: Elements
-  default: Default
+  elements: ELEMENTS
+  default: DEFAULT
 }
 
-export type FreezeSetAttribute<Attribute extends _SetAttribute> = SetAttribute<
-  FreezeAttribute<Attribute['_elements']>,
-  Attribute['_required'],
-  Attribute['_hidden'],
-  Attribute['_key'],
-  Attribute['_savedAs'],
-  Attribute['_default']
+export type FreezeSetAttribute<_SET_ATTRIBUTE extends _SetAttribute> = SetAttribute<
+  FreezeAttribute<_SET_ATTRIBUTE['_elements']>,
+  _SET_ATTRIBUTE['_required'],
+  _SET_ATTRIBUTE['_hidden'],
+  _SET_ATTRIBUTE['_key'],
+  _SET_ATTRIBUTE['_savedAs'],
+  _SET_ATTRIBUTE['_default']
 >

--- a/src/v1/item/attributes/set/options.ts
+++ b/src/v1/item/attributes/set/options.ts
@@ -6,16 +6,16 @@ import { ComputedDefault } from '../constants/computedDefault'
  * Input options of Set Attribute
  */
 export interface SetAttributeOptions<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined,
-  Default extends ComputedDefault | undefined = ComputedDefault | undefined
-> extends AttributeOptions<IsRequired, IsHidden, IsKey, SavedAs> {
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined,
+  DEFAULT extends ComputedDefault | undefined = ComputedDefault | undefined
+> extends AttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS> {
   /**
    * Tag attribute as having a computed default value
    */
-  default: Default
+  default: DEFAULT
 }
 
 export const SET_ATTRIBUTE_DEFAULT_OPTIONS: SetAttributeOptions<

--- a/src/v1/item/attributes/set/typer.ts
+++ b/src/v1/item/attributes/set/typer.ts
@@ -8,16 +8,16 @@ import { SetAttributeOptions, SET_ATTRIBUTE_DEFAULT_OPTIONS } from './options'
 import type { _SetAttributeElements } from './types'
 
 type SetTyper = <
-  Elements extends _SetAttributeElements,
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ELEMENTS extends _SetAttributeElements,
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  _elements: Elements,
-  options?: O.Partial<SetAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-) => _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  _elements: ELEMENTS,
+  options?: O.Partial<SetAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+) => _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 
 /**
  * Define a new set attribute
@@ -31,16 +31,16 @@ type SetTyper = <
  * @param options _(optional)_ List Options
  */
 export const set: SetTyper = <
-  Elements extends _SetAttributeElements,
-  IsRequired extends RequiredOption = Never,
-  IsHidden extends boolean = false,
-  IsKey extends boolean = false,
-  SavedAs extends string | undefined = undefined,
-  Default extends ComputedDefault | undefined = undefined
+  ELEMENTS extends _SetAttributeElements,
+  IS_REQUIRED extends RequiredOption = Never,
+  IS_HIDDEN extends boolean = false,
+  IS_KEY extends boolean = false,
+  SAVED_AS extends string | undefined = undefined,
+  DEFAULT extends ComputedDefault | undefined = undefined
 >(
-  elements: Elements,
-  options?: O.Partial<SetAttributeOptions<IsRequired, IsHidden, IsKey, SavedAs, Default>>
-): _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default> => {
+  elements: ELEMENTS,
+  options?: O.Partial<SetAttributeOptions<IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>>
+): _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT> => {
   const appliedOptions = { ...SET_ATTRIBUTE_DEFAULT_OPTIONS, ...options }
   const {
     required: _required,
@@ -58,12 +58,12 @@ export const set: SetTyper = <
     _key,
     _savedAs,
     _default,
-    required: <NextIsRequired extends RequiredOption = AtLeastOnce>(
-      nextRequired: NextIsRequired = 'atLeastOnce' as NextIsRequired
+    required: <NEXT_IS_REQUIRED extends RequiredOption = AtLeastOnce>(
+      nextRequired: NEXT_IS_REQUIRED = 'atLeastOnce' as NEXT_IS_REQUIRED
     ) => set(elements, { ...appliedOptions, required: nextRequired }),
     hidden: () => set(elements, { ...appliedOptions, hidden: true }),
     key: () => set(elements, { ...appliedOptions, key: true }),
     savedAs: nextSavedAs => set(elements, { ...appliedOptions, savedAs: nextSavedAs }),
     default: nextDefault => set(elements, { ...appliedOptions, default: nextDefault })
-  } as _SetAttribute<Elements, IsRequired, IsHidden, IsKey, SavedAs, Default>
+  } as _SetAttribute<ELEMENTS, IS_REQUIRED, IS_HIDDEN, IS_KEY, SAVED_AS, DEFAULT>
 }

--- a/src/v1/item/attributes/shared/interface.ts
+++ b/src/v1/item/attributes/shared/interface.ts
@@ -1,25 +1,25 @@
 import { RequiredOption } from '../constants/requiredOptions'
 
 export interface _AttributeProperties<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined
 > {
-  _required: IsRequired
-  _hidden: IsHidden
-  _key: IsKey
-  _savedAs: SavedAs
+  _required: IS_REQUIRED
+  _hidden: IS_HIDDEN
+  _key: IS_KEY
+  _savedAs: SAVED_AS
 }
 
 export interface AttributeProperties<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined
 > {
-  required: IsRequired
-  hidden: IsHidden
-  key: IsKey
-  savedAs: SavedAs
+  required: IS_REQUIRED
+  hidden: IS_HIDDEN
+  key: IS_KEY
+  savedAs: SAVED_AS
 }

--- a/src/v1/item/attributes/shared/options.ts
+++ b/src/v1/item/attributes/shared/options.ts
@@ -4,10 +4,10 @@ import { RequiredOption } from '../constants/requiredOptions'
  * Common input options of all Attributes
  */
 export interface AttributeOptions<
-  IsRequired extends RequiredOption = RequiredOption,
-  IsHidden extends boolean = boolean,
-  IsKey extends boolean = boolean,
-  SavedAs extends string | undefined = string | undefined
+  IS_REQUIRED extends RequiredOption = RequiredOption,
+  IS_HIDDEN extends boolean = boolean,
+  IS_KEY extends boolean = boolean,
+  SAVED_AS extends string | undefined = string | undefined
 > {
   /**
    * Tag attribute as required. Possible values are:
@@ -16,17 +16,17 @@ export interface AttributeOptions<
    * - `"always"`: Required in PUTs and UPDATEs
    * - `"onlyOnce"`: Required in PUTs, denied in UPDATEs
    */
-  required: IsRequired
+  required: IS_REQUIRED
   /**
    * Hide attribute after fetch commands and formatting
    */
-  hidden: IsHidden
+  hidden: IS_HIDDEN
   /**
    * Tag attribute as needed for Primary Key computing
    */
-  key: IsKey
+  key: IS_KEY
   /**
    * Rename attribute before save commands
    */
-  savedAs: SavedAs
+  savedAs: SAVED_AS
 }

--- a/src/v1/item/attributes/types/narrow.ts
+++ b/src/v1/item/attributes/types/narrow.ts
@@ -6,10 +6,8 @@ import { _MapAttributeAttributes, _Attribute } from './attribute'
  * @param AttributeInput MapAttributeAttributes | Attribute
  * @return MapAttributeAttributes | Attribute
  */
-export type Narrow<AttributeInput extends _MapAttributeAttributes | _Attribute> = {
-  [AttributeProperty in keyof AttributeInput]: AttributeInput[AttributeProperty] extends
-    | _MapAttributeAttributes
-    | _Attribute
-    ? Narrow<AttributeInput[AttributeProperty]>
-    : AttributeInput[AttributeProperty]
+export type Narrow<_ATTRIBUTE extends _MapAttributeAttributes | _Attribute> = {
+  [PROPERTY in keyof _ATTRIBUTE]: _ATTRIBUTE[PROPERTY] extends _MapAttributeAttributes | _Attribute
+    ? Narrow<_ATTRIBUTE[PROPERTY]>
+    : _ATTRIBUTE[PROPERTY]
 }

--- a/src/v1/item/freeze.ts
+++ b/src/v1/item/freeze.ts
@@ -2,11 +2,9 @@ import { _Item, FreezeItem } from './interface'
 import { FreezeAttribute, freezeAttribute } from './attributes/freeze'
 import { RequiredOption } from './attributes/constants/requiredOptions'
 
-type ItemFreezer = <ItemInput extends _Item>(item: ItemInput) => FreezeItem<ItemInput>
+type ItemFreezer = <_ITEM extends _Item>(item: _ITEM) => FreezeItem<_ITEM>
 
-export const freezeItem: ItemFreezer = <ItemInput extends _Item>(
-  item: ItemInput
-): FreezeItem<ItemInput> => {
+export const freezeItem: ItemFreezer = <_ITEM extends _Item>(item: _ITEM): FreezeItem<_ITEM> => {
   const { _type: type, _open: open } = item
 
   const attributesSavedAs = new Set<string>()
@@ -18,9 +16,9 @@ export const freezeItem: ItemFreezer = <ItemInput extends _Item>(
     never: new Set()
   }
 
-  const attributes: ItemInput['_attributes'] = item._attributes
+  const attributes: _ITEM['_attributes'] = item._attributes
   const frozenAttributes: {
-    [key in keyof ItemInput['_attributes']]: FreezeAttribute<ItemInput['_attributes'][key]>
+    [key in keyof _ITEM['_attributes']]: FreezeAttribute<_ITEM['_attributes'][key]>
   } = {} as any
 
   for (const attributeName in attributes) {

--- a/src/v1/item/generics/HasComputedDefaults.ts
+++ b/src/v1/item/generics/HasComputedDefaults.ts
@@ -14,16 +14,18 @@ import type {
  * @param Input Item | Attribute
  * @return Boolean
  */
-export type _HasComputedDefaults<Input extends _Item | _Attribute> = Input extends {
+export type _HasComputedDefaults<INPUT extends _Item | _Attribute> = INPUT extends {
   _default: ComputedDefault
 }
   ? true
-  : Input extends _SetAttribute | _ListAttribute
-  ? _HasComputedDefaults<Input['_elements']>
-  : Input extends _MapAttribute | _Item
+  : INPUT extends _SetAttribute | _ListAttribute
+  ? _HasComputedDefaults<INPUT['_elements']>
+  : INPUT extends _MapAttribute | _Item
   ? true extends {
-      [K in keyof Input['_attributes']]: _HasComputedDefaults<Input['_attributes'][K]>
-    }[keyof Input['_attributes']]
+      [ATTRIBUTE_NAME in keyof INPUT['_attributes']]: _HasComputedDefaults<
+        INPUT['_attributes'][ATTRIBUTE_NAME]
+      >
+    }[keyof INPUT['_attributes']]
     ? true
     : false
   : never

--- a/src/v1/item/interface.ts
+++ b/src/v1/item/interface.ts
@@ -8,26 +8,26 @@ import { FreezeAttribute } from './attributes/freeze'
  * @return Item
  */
 export interface _Item<
-  MapAttributeAttributesInput extends _MapAttributeAttributes = _MapAttributeAttributes
+  _MAP_ATTRIBUTE_ATTRIBUTES extends _MapAttributeAttributes = _MapAttributeAttributes
 > {
   _type: 'item'
   _open: boolean
-  _attributes: MapAttributeAttributesInput
+  _attributes: _MAP_ATTRIBUTE_ATTRIBUTES
 }
 
 export interface Item<
-  MapAttributeAttributesInput extends MapAttributeAttributes = MapAttributeAttributes
+  MAP_ATTRIBUTE_ATTRIBUTES extends MapAttributeAttributes = MapAttributeAttributes
 > {
   type: 'item'
   open: boolean
   requiredAttributesNames: Record<RequiredOption, Set<string>>
-  attributes: MapAttributeAttributesInput
+  attributes: MAP_ATTRIBUTE_ATTRIBUTES
 }
 
-export type FreezeItem<ItemInput extends _Item> = _Item extends ItemInput
+export type FreezeItem<_ITEM extends _Item> = _Item extends _ITEM
   ? Item
   : Item<
       {
-        [key in keyof ItemInput['_attributes']]: FreezeAttribute<ItemInput['_attributes'][key]>
+        [key in keyof _ITEM['_attributes']]: FreezeAttribute<_ITEM['_attributes'][key]>
       }
     >

--- a/src/v1/item/typer.ts
+++ b/src/v1/item/typer.ts
@@ -1,9 +1,9 @@
 import type { _MapAttributeAttributes, Narrow } from './attributes/types'
 import type { _Item } from './interface'
 
-type ItemTyper = <MapAttributeAttributesInput extends _MapAttributeAttributes = {}>(
-  _attributes: Narrow<MapAttributeAttributesInput>
-) => _Item<MapAttributeAttributesInput>
+type ItemTyper = <_MAP_ATTRIBUTE_ATTRIBUTES extends _MapAttributeAttributes = {}>(
+  _attributes: Narrow<_MAP_ATTRIBUTE_ATTRIBUTES>
+) => _Item<_MAP_ATTRIBUTE_ATTRIBUTES>
 
 // TODO: Enable item opening
 /**
@@ -12,11 +12,11 @@ type ItemTyper = <MapAttributeAttributesInput extends _MapAttributeAttributes = 
  * @param attributes Object of attributes
  * @return Item
  */
-export const item: ItemTyper = <MapAttributeAttributesInput extends _MapAttributeAttributes = {}>(
-  attributes: Narrow<MapAttributeAttributesInput>
-): _Item<MapAttributeAttributesInput> =>
+export const item: ItemTyper = <_MAP_ATTRIBUTE_ATTRIBUTES extends _MapAttributeAttributes = {}>(
+  attributes: Narrow<_MAP_ATTRIBUTE_ATTRIBUTES>
+): _Item<_MAP_ATTRIBUTE_ATTRIBUTES> =>
   ({
     _type: 'item',
     _open: false,
     _attributes: attributes
-  } as _Item<MapAttributeAttributesInput>)
+  } as _Item<_MAP_ATTRIBUTE_ATTRIBUTES>)

--- a/src/v1/table/class.ts
+++ b/src/v1/table/class.ts
@@ -2,11 +2,11 @@ import type { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 
 import { Key, NarrowKey } from './types'
 
-export class TableV2<PartitionKey extends Key = Key, SortKey extends Key = Key> {
+export class TableV2<PARTITION_KEY extends Key = Key, SORT_KEY extends Key = Key> {
   public dynamoDbClient: DynamoDBClient
   public name: string
-  public partitionKey: PartitionKey
-  public sortKey?: SortKey
+  public partitionKey: PARTITION_KEY
+  public sortKey?: SORT_KEY
 
   /**
    * Define a Table
@@ -25,8 +25,8 @@ export class TableV2<PartitionKey extends Key = Key, SortKey extends Key = Key> 
   }: {
     dynamoDbClient: DynamoDBClient
     name: string
-    partitionKey: NarrowKey<PartitionKey>
-    sortKey?: NarrowKey<SortKey>
+    partitionKey: NarrowKey<PARTITION_KEY>
+    sortKey?: NarrowKey<SORT_KEY>
   }) {
     this.dynamoDbClient = dynamoDbClient
     this.name = name

--- a/src/v1/table/generics/hasSk.ts
+++ b/src/v1/table/generics/hasSk.ts
@@ -7,6 +7,4 @@ import { Key } from '../types'
  * @param TableInput Table
  * @return Boolean
  */
-export type HasSK<TableInput extends TableV2 = TableV2> = Key extends TableInput['sortKey']
-  ? false
-  : true
+export type HasSK<TABLE extends TableV2 = TableV2> = Key extends TABLE['sortKey'] ? false : true

--- a/src/v1/table/generics/primaryKey.ts
+++ b/src/v1/table/generics/primaryKey.ts
@@ -9,20 +9,18 @@ import { HasSK } from './hasSk'
  * @param TableInput Table
  * @return Object
  */
-export type PrimaryKey<TableInput extends TableV2 = TableV2> = TableV2 extends TableInput
+export type PrimaryKey<TABLE extends TableV2 = TableV2> = TableV2 extends TABLE
   ? Record<string, ResolveIndexableKeyType<IndexableKeyType>>
-  : HasSK<TableInput> extends true
+  : HasSK<TABLE> extends true
   ? {
       [K in
-        | TableInput['partitionKey']['name']
-        | NonNullable<TableInput['sortKey']>['name']]: K extends TableInput['partitionKey']['name']
-        ? ResolveIndexableKeyType<TableInput['partitionKey']['type']>
-        : K extends NonNullable<TableInput['sortKey']>['name']
-        ? ResolveIndexableKeyType<NonNullable<TableInput['sortKey']>['type']>
+        | TABLE['partitionKey']['name']
+        | NonNullable<TABLE['sortKey']>['name']]: K extends TABLE['partitionKey']['name']
+        ? ResolveIndexableKeyType<TABLE['partitionKey']['type']>
+        : K extends NonNullable<TABLE['sortKey']>['name']
+        ? ResolveIndexableKeyType<NonNullable<TABLE['sortKey']>['type']>
         : never
     }
   : {
-      [K in TableInput['partitionKey']['name']]: ResolveIndexableKeyType<
-        TableInput['partitionKey']['type']
-      >
+      [K in TABLE['partitionKey']['name']]: ResolveIndexableKeyType<TABLE['partitionKey']['type']>
     }

--- a/src/v1/table/types/key.ts
+++ b/src/v1/table/types/key.ts
@@ -8,11 +8,11 @@ import { IndexableKeyType } from './keyType'
  * @return Key
  */
 export interface Key<
-  KeyName extends string = string,
-  KeyType extends IndexableKeyType = IndexableKeyType
+  KEY_NAME extends string = string,
+  KEY_TYPE extends IndexableKeyType = IndexableKeyType
 > {
-  name: KeyName
-  type: KeyType
+  name: KEY_NAME
+  type: KEY_TYPE
 }
 
 /**
@@ -21,6 +21,6 @@ export interface Key<
  * @param KeyInput Key
  * @return Key
  */
-export type NarrowKey<KeyInput extends Key> = {
-  [Property in keyof KeyInput]: KeyInput[Property]
+export type NarrowKey<KEY_INPUT extends Key> = {
+  [Property in keyof KEY_INPUT]: KEY_INPUT[Property]
 }

--- a/src/v1/table/types/keyType.ts
+++ b/src/v1/table/types/keyType.ts
@@ -9,10 +9,10 @@ export type IndexableKeyType = 'string' | 'binary' | 'number'
  * @param KeyType Attribute Type
  * @return Type
  */
-export type ResolveIndexableKeyType<KeyType extends IndexableKeyType> = KeyType extends 'string'
+export type ResolveIndexableKeyType<KEY_TYPE extends IndexableKeyType> = KEY_TYPE extends 'string'
   ? string
-  : KeyType extends 'number'
+  : KEY_TYPE extends 'number'
   ? number
-  : KeyType extends 'binary'
+  : KEY_TYPE extends 'binary'
   ? Buffer
   : never


### PR DESCRIPTION
Generics used to be a single letter, which allowed to distinguish them from their constraints. But it made core less readable:

```ts
const doSomethingWithEntity = <E extends Entity>(entity: E) => ...
```

My pb after renaming is that it was not easy to distinguish the generic from the constraint. I awkwardly added `Input` when necessary to do that:

```ts
const doSomethingWithEntity = <EntityInput extends Entity>(entity: EntityInput) => ...
```

After scraching my head around, I found that using uppercase was not that bad:

```ts
const doSomethingWithEntity = <ENTITY extends Entity>(entity: ENTITY) => ...
```