### PR TITLE
chore (Entity): filter items of other entities

### DIFF
--- a/src/classes/Entity/Entity.ts
+++ b/src/classes/Entity/Entity.ts
@@ -1763,7 +1763,7 @@ class Entity<
   }
 
   // Query pass-through (default entity)
-  query<
+  async query<
     MethodItemOverlay extends Overlay = undefined,
     ItemAttributes extends { all: A.Key; shown: A.Key } = If<
       A.Equals<MethodItemOverlay, undefined>,
@@ -1783,16 +1783,21 @@ class Entity<
       throw new Error('Entity table is not defined')
     }
 
-    options.entity = this.name
-    return this.table.query<
+    options.entity = this.name // I don't think this is working
+    const queryResult = await this.table.query<
       FirstDefined<[MethodItemOverlay, O.Pick<Item, ResponseAttributes>]>,
       Execute,
       Parse
     >(pk, options, params)
+
+    return {
+      ...queryResult,
+      Items: queryResult?.Items?.filter((item: any) => item[this.table.entityField] === this.name)
+    }
   }
 
   // Scan pass-through (default entity)
-  scan<
+  async scan<
     MethodItemOverlay extends Overlay = undefined,
     Execute extends boolean | undefined = undefined,
     Parse extends boolean | undefined = undefined
@@ -1801,12 +1806,17 @@ class Entity<
       throw new Error('Entity table is not defined')
     }
 
-    options.entity = this.name
-    return this.table.scan<
+    options.entity = this.name // I don't think this is working
+    const scanResult = await this.table.scan<
       FirstDefined<[MethodItemOverlay, DocumentClient.AttributeMap]>,
       Execute,
       Parse
     >(options, params)
+
+    return {
+      ...scanResult,
+      Items: scanResult?.Items?.filter((item: any) => item[this.table.entityField] === this.name)
+    }
   }
 } // end Entity
 


### PR DESCRIPTION
This is a draft suggestion or poc, and I don't know the exact effect of this on the project structure, but it is open for discussion. 

I'm happy to put some more efforts into this if you think this is a good idea.

## Problem

- Currently, when using entity query or scan, it passes it to the table's function setting the entity option. 
- In theory, that should return only items that belong to the entity in question; however, [according to the docs](https://www.dynamodbtoolbox.com/docs/entity/methods#query) no guarantee that only items of the current entity type will be returned. 

## Combatibility

- This is a breaking change and will change the behaviour of the old code.

## Notes

- I chose the easiest solution, filtering items after the `table.scan` or `table.query` has done their jobs, but there is definitely room for improvement. 
- Another possibility is to work on the [expression builder](https://github.com/ahmad-ali14/dynamodb-toolbox/blob/57f6a3e090ec6b44aac184cce8a3234691458ee2/src/lib/expressionBuilder.ts#L47) to include `{ attr: 'entity', eq: entity }`, but that seemed very complex to me; pulse this function is already used in multiple scenarios; I'm not comfortable changing it.

Thanks.

