### PR TITLE
fix: remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "peerDependencies": {
-    "@aws-sdk/lib-dynamodb": "^3.0.0",
-    "@aws-sdk/client-dynamodb": "^3.0.0"
-  },
   "devDependencies": {
     "@types/jest": "^29.2.1",
     "@types/node": "^14.14.16",


### PR DESCRIPTION
Designating `@aws-sdk/client-dynamodb` as a **peerDependency** can lead to less-than-optimal consequences in certain environments. Specifically, bundling tools such as Webpack or ESBuild, which are often used in Serverless applications, will automatically install the `@aws-sdk` dependency on newer NPM versions. This action subsequently pulls in all associated transitive dependencies. For AWS Lambda environments, this approach is not recommended. Lambda environments already include these dependencies in the runtime. Consequently, it is preferable and more efficient to utilize the `@aws-sdk` that is readily available in the runtime, as per AWS recommendations.
