### PR TITLE
doc: update installation guide for aws v3

### DIFF
--- a/docs/docs/introduction/quick-start.md
+++ b/docs/docs/introduction/quick-start.md
@@ -1,6 +1,21 @@
 # Quick Start
 
-## Install DynamoDB Toolbox
+## Install DynamoDB Toolbox using aws-sdk v3 (>=v0.8.0) (recommended)
+
+Using your favorite package manager, install DynamoDB Toolbox and aws-sdk v3 in your project by running one of the following commands:
+
+```bash
+# npm
+npm i dynamodb-toolbox
+npm install @aws-sdk/lib-dynamodb @aws-sdk/client-dynamodb
+
+# yarn
+yarn add dynamodb-toolbox
+yarn add @aws-sdk/lib-dynamodb @aws-sdk/client-dynamodb
+
+```
+
+## Install DynamoDB Toolbox using aws-sdk v2 (<v0.8.0)
 
 Using your favorite package manager, install DynamoDB Toolbox and aws-sdk v2 in your project by running one of the following commands:
 
@@ -14,7 +29,6 @@ yarn add dynamodb-toolbox
 yarn add aws-sdk
 
 ```
-
 ## Add to your code
 
 The `dynamodb-toolbox` package exports `Table` and `Entity` classes. Import or require them into your code as follows:
@@ -30,8 +44,7 @@ import { Table, Entity } from 'dynamodb-toolbox'
 ## Load the DocumentClient using aws-sdk v3 (>=v0.8.0)
 
 ```typescript title="TypeScript"
-import { DynamoDB } from '@aws-sdk/client-dynamodb'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDB, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb'
 
 const marshallOptions = {

--- a/docs/docs/introduction/what-is-dynamodb-toolbox.md
+++ b/docs/docs/introduction/what-is-dynamodb-toolbox.md
@@ -79,8 +79,7 @@ This library **DOES NOT** create DynamoDB Tables for you. You must create the ta
 ```typescript
 
 // >=v0.8.0
-import { DynamoDB } from '@aws-sdk/client-dynamodb'
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { DynamoDB, DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb'
 
 const marshallOptions = {


### PR DESCRIPTION
Currently, the installation guide only includes that for aws-sdk v2, with aws-sdk v2 soon to go into maintenance mode, we should update the installation guide to also include aws-sdk v3 as the recommended.

This PR also fixed duplicate imports from `'@aws-sdk/client-dynamodb'`.

Please let me know your thoughts.