### PR TITLE
fix(lib/validate-types): resolve attr type changed to number when using bigint

### DIFF
--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -1,5 +1,5 @@
 import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { DocumentClient, DocumentClientWithWrappedNumbers } from './bootstrap.test'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -1,5 +1,5 @@
 import { Table, Entity } from '../index'
-import { DocumentClient, DocumentClientWithWrappedNumbers } from './bootstrap.test'
+import { DocumentClient } from './bootstrap.test'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/validateTypes.unit.test.ts
+++ b/src/__tests__/validateTypes.unit.test.ts
@@ -169,7 +169,8 @@ describe('validateTypes', () => {
   })
 
   it('converts arrays of bigints to sets', async () => {
-    const result = validateTypes()({ type: 'set', setType: 'bigint' }, 'attr', [
+    const attr = { type: 'set', setType: 'bigint' }
+    const result = validateTypes()(attr, 'attr', [
       BigInt(-1234),
       BigInt('123000000000000000000001')
     ])
@@ -177,5 +178,7 @@ describe('validateTypes', () => {
       toDynamoBigInt(BigInt(-1234)),
       toDynamoBigInt(BigInt('123000000000000000000001'))
     ]))
+    // Should not mutate the attribute
+    expect(attr.setType).toEqual('bigint')
   })
 })

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -61,7 +61,6 @@ export default () => (mapping: any, field: any, value: any) => {
       if (value instanceof Set) {
 
         if (mapping.setType === 'bigint') {
-          mapping.setType = 'number'
           value = Array.from(value).map((n) => toDynamoBigInt(n))
         }
 
@@ -78,7 +77,6 @@ export default () => (mapping: any, field: any, value: any) => {
         const actualSetType = typeOf(value[0])?.toLowerCase?.()
 
         if (mapping.setType === 'bigint') {
-          mapping.setType = 'number'
           value = value.map((n) => toDynamoBigInt(n))
         }
 


### PR DESCRIPTION
Fix #592

Attribute definitions should _never_ be mutated, as this will result in changing the data types returned by future reads, and potentially cause catastrophic loss of precision. This PR removes the mutating code.
