### PR TITLE
feat: dual module export

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,7 +3,16 @@ module.exports = {
   testMatch: ['**/?(*.)+(unit.test).+(ts|tsx|js)'],
   testPathIgnorePatterns: ['/__tests__/entities/*', '/__tests__/tables/*'],
   coveragePathIgnorePatterns: ['/__tests__/*'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest'
-  }
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
 }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,21 @@
   "name": "dynamodb-toolbox",
   "description": "A simple set of tools for working with Amazon DynamoDB and the DocumentClient.",
   "author": "Jeremy Daly <jeremy@jeremydaly.com>",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/esm/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/cjs/index.d.ts"
+      }
+    }
+  },
+  "type": "module",
   "scripts": {
     "test": "jest unit",
     "test-cov": "jest unit --coverage",
@@ -11,7 +24,10 @@
     "test-types": "tsd",
     "check-types": "tsc --noEmit",
     "lint": "eslint .",
-    "build": "rm -rf dist && tsc -p tsconfig.build.json",
+    "build:cjs": "tsc -p tsconfig.build.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
+    "build:esm": "tsc -p tsconfig.esm.json && echo '{ \"type\": \"module\" }' > dist/esm/package.json",
+    "build": "npm run build:cjs & npm run build:esm",
+    "prebuild": "rm -rf dist",
     "prepublishOnly": "npm test && npm run lint && npm run test-types",
     "changelog": "git log $(git describe --tags --abbrev=0)..HEAD --oneline"
   },

--- a/package.json
+++ b/package.json
@@ -78,9 +78,13 @@
     "typescript": "^4.1.3"
   },
   "files": [
-    "dist/index.*",
-    "dist/constants.*",
-    "dist/classes/",
-    "dist/lib/"
+    "dist/cjs/index.*",
+    "dist/cjs/constants.*",
+    "dist/cjs/classes/",
+    "dist/cjs/lib/",
+    "dist/esm/index.*",
+    "dist/esm/constants.*",
+    "dist/esm/classes/",
+    "dist/esm/lib/"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-types": "tsd",
     "check-types": "tsc --noEmit",
     "lint": "eslint .",
-    "build:cjs": "tsc -p tsconfig.build.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
     "build:esm": "tsc -p tsconfig.esm.json && echo '{ \"type\": \"module\" }' > dist/esm/package.json",
     "build": "npm run build:cjs & npm run build:esm",
     "prebuild": "rm -rf dist",

--- a/src/__tests__/checkAttribute.unit.test.ts
+++ b/src/__tests__/checkAttribute.unit.test.ts
@@ -1,8 +1,8 @@
-import checkAttribute from '../lib/checkAttribute'
+import checkAttribute from '../lib/checkAttribute.js'
 
 // Require Table and Entity classes
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 
 // Create basic table
 const DefaultTable = new Table({

--- a/src/__tests__/entity-creation.unit.test.ts
+++ b/src/__tests__/entity-creation.unit.test.ts
@@ -1,6 +1,6 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
-import { DocumentClient, DocumentClientWithWrappedNumbers } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
+import { DocumentClient, DocumentClientWithWrappedNumbers } from './bootstrap.test.js'
 
 const tableAddEntity = jest.spyOn(Table.prototype, 'addEntity').mockReturnValue()
 

--- a/src/__tests__/entity-properties.unit.test.ts
+++ b/src/__tests__/entity-properties.unit.test.ts
@@ -1,5 +1,5 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 
 describe('Entity properties', () => {
   describe('table', () => {

--- a/src/__tests__/entity.delete.unit.test.ts
+++ b/src/__tests__/entity.delete.unit.test.ts
@@ -1,5 +1,5 @@
 import { Entity, Table } from '..'
-import { DocumentClient } from './bootstrap.test'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/entity.get.int.test.ts
+++ b/src/__tests__/entity.get.int.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/entity.get.unit.test.ts
+++ b/src/__tests__/entity.get.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '..'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/entity.parse.unit.test.ts
+++ b/src/__tests__/entity.parse.unit.test.ts
@@ -1,7 +1,7 @@
-import { DocumentClientWithWrappedNumbers } from './bootstrap.test'
+import { DocumentClientWithWrappedNumbers } from './bootstrap.test.js'
 
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 
 const TestTable = new Table({

--- a/src/__tests__/entity.put.unit.test.ts
+++ b/src/__tests__/entity.put.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/entity.putBatch.unit.test.ts
+++ b/src/__tests__/entity.putBatch.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/entity.transaction.unit.test.ts
+++ b/src/__tests__/entity.transaction.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/entity.update.unit.test.ts
+++ b/src/__tests__/entity.update.unit.test.ts
@@ -1,9 +1,9 @@
 import {
   ATTRIBUTE_VALUES_LIST_DEFAULT_KEY,
   ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE
-} from '../constants'
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+} from '../constants.js'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/entity.utils.unit.test.ts
+++ b/src/__tests__/entity.utils.unit.test.ts
@@ -1,4 +1,4 @@
-import { shouldExecute, shouldParse } from '../classes/Entity'
+import { shouldExecute, shouldParse } from '../classes/Entity/Entity.js'
 
 describe('Entity - utils', () => {
   it('should execute', () => {

--- a/src/__tests__/expressionBuilder.unit.test.ts
+++ b/src/__tests__/expressionBuilder.unit.test.ts
@@ -1,9 +1,9 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 import {
   default as expressionBuilder,
   SUPPORTED_FILTER_EXP_ATTR_REF_OPERATORS
-} from '../lib/expressionBuilder'
+} from '../lib/expressionBuilder.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/format.unit.test.ts
+++ b/src/__tests__/format.unit.test.ts
@@ -1,6 +1,6 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
-import { DocumentClient } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/formatItem.unit.test.ts
+++ b/src/__tests__/formatItem.unit.test.ts
@@ -1,9 +1,9 @@
-import formatItem from '../lib/formatItem'
+import formatItem from '../lib/formatItem.js'
 
-import { DocumentClient } from './bootstrap.test'
+import { DocumentClient } from './bootstrap.test.js'
 
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 
 // Create basic table
 const DefaultTable = new Table({

--- a/src/__tests__/misc-tests.unit.test.ts
+++ b/src/__tests__/misc-tests.unit.test.ts
@@ -1,6 +1,6 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
-import { DocumentClient } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 describe('Misc Tests (development only)', () => {
   it('uses a numeric pk value', async () => {

--- a/src/__tests__/normalizeData.unit.test.ts
+++ b/src/__tests__/normalizeData.unit.test.ts
@@ -1,9 +1,9 @@
-import normalizeData from '../lib/normalizeData'
+import normalizeData from '../lib/normalizeData.js'
 
-import { DocumentClient } from './bootstrap.test'
+import { DocumentClient } from './bootstrap.test.js'
 
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 
 const DefaultTable = new Table({
   name: 'test-table',

--- a/src/__tests__/parse-alias.unit.test.ts
+++ b/src/__tests__/parse-alias.unit.test.ts
@@ -1,6 +1,6 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
-import { DocumentClient } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-alias',

--- a/src/__tests__/parse.unit.test.ts
+++ b/src/__tests__/parse.unit.test.ts
@@ -1,6 +1,6 @@
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
-import { DocumentClient } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/parseCompositeKey.unit.test.ts
+++ b/src/__tests__/parseCompositeKey.unit.test.ts
@@ -1,5 +1,5 @@
-import { TrackingInfo } from '../lib/parseEntity'
-import parseCompositeKey from '../lib/parseCompositeKey'
+import { TrackingInfo } from '../lib/parseEntity.js'
+import parseCompositeKey from '../lib/parseCompositeKey.js'
 
 // Simulate attributes
 const attributes = {

--- a/src/__tests__/parseEntity.unit.test.ts
+++ b/src/__tests__/parseEntity.unit.test.ts
@@ -1,4 +1,4 @@
-import parseEntity from '../lib/parseEntity'
+import parseEntity from '../lib/parseEntity.js'
 
 // Simulate Entity config
 const entity = {

--- a/src/__tests__/parseMapping.unit.test.ts
+++ b/src/__tests__/parseMapping.unit.test.ts
@@ -1,5 +1,5 @@
-import parseMapping from '../lib/parseMapping'
-import { TrackingInfo } from '../lib/parseEntity'
+import parseMapping from '../lib/parseMapping.js'
+import { TrackingInfo } from '../lib/parseEntity.js'
 
 let track: TrackingInfo = {
   fields: [],

--- a/src/__tests__/parseTable.unit.test.ts
+++ b/src/__tests__/parseTable.unit.test.ts
@@ -1,7 +1,7 @@
-import parseTable from '../lib/parseTable'
+import parseTable from '../lib/parseTable.js'
 
 // Require Table and Entity classes
-import { TableConstructor } from '../classes/Table'
+import { TableConstructor } from '../classes/Table/types.js'
 
 const table: TableConstructor<'test-table', 'pk', 'sk'> = {
   name: 'test-table',

--- a/src/__tests__/parseTableAttributes.unit.test.ts
+++ b/src/__tests__/parseTableAttributes.unit.test.ts
@@ -1,5 +1,5 @@
-import { TableAttributes } from '../classes/Table'
-import parseTableAttributes from '../lib/parseTableAttributes'
+import { TableAttributes } from '../classes/Table/types.js'
+import parseTableAttributes from '../lib/parseTableAttributes.js'
 
 const attrs: TableAttributes = {
   pk: 'string',

--- a/src/__tests__/projectionBuilder.unit.test.ts
+++ b/src/__tests__/projectionBuilder.unit.test.ts
@@ -1,7 +1,7 @@
-import projectionBuilder from '../lib/projectionBuilder'
+import projectionBuilder from '../lib/projectionBuilder.js'
 
-import Table from '../classes/Table'
-import Entity from '../classes/Entity'
+import Table from '../classes/Table/Table.js'
+import Entity from '../classes/Entity/Entity.js'
 
 const DefaultTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table-creation.unit.test.ts
+++ b/src/__tests__/table-creation.unit.test.ts
@@ -1,5 +1,5 @@
-import Table from '../classes/Table'
-import { DocumentClient, DocumentClientWithoutConfig } from './bootstrap.test'
+import Table from '../classes/Table/Table.js'
+import { DocumentClient, DocumentClientWithoutConfig } from './bootstrap.test.js'
 
 describe('Table creation', () => {
   it('creates table w/ minimum options', async () => {

--- a/src/__tests__/table.batchGet.unit.test.ts
+++ b/src/__tests__/table.batchGet.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table.batchWrite.unit.test.ts
+++ b/src/__tests__/table.batchWrite.unit.test.ts
@@ -1,6 +1,6 @@
 import { BatchWriteCommandInput } from '@aws-sdk/lib-dynamodb'
-import { Entity, Table } from '../index'
-import { DocumentClient as docClient } from './bootstrap.test'
+import { Entity, Table } from '../index.js'
+import { DocumentClient as docClient } from './bootstrap.test.js'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/table.entities.unit.test.ts
+++ b/src/__tests__/table.entities.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 let TestTable: any
 let TestEntity: any

--- a/src/__tests__/table.entity-actions.unit.test.ts
+++ b/src/__tests__/table.entity-actions.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table.query.unit.test.ts
+++ b/src/__tests__/table.query.unit.test.ts
@@ -1,5 +1,5 @@
-import { Entity, Table } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Entity, Table } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table.scan.unit.test.ts
+++ b/src/__tests__/table.scan.unit.test.ts
@@ -1,5 +1,5 @@
-import { Entity, Table } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Entity, Table } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table.transactGet.unit.test.ts
+++ b/src/__tests__/table.transactGet.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient } from './bootstrap.test.js'
 
 const TestTable = new Table({
   name: 'test-table',

--- a/src/__tests__/table.transactWrite.unit.test.ts
+++ b/src/__tests__/table.transactWrite.unit.test.ts
@@ -1,5 +1,5 @@
-import { Table, Entity } from '../index'
-import { DocumentClient as docClient } from './bootstrap.test'
+import { Table, Entity } from '../index.js'
+import { DocumentClient as docClient } from './bootstrap.test.js'
 import assert from 'assert'
 
 const TestTable = new Table({

--- a/src/__tests__/type-infering.unit.test.ts
+++ b/src/__tests__/type-infering.unit.test.ts
@@ -20,7 +20,7 @@ import {
   PutCommandInput, PutCommandOutput, QueryCommandInput, ScanCommandInput,
   UpdateCommandInput, UpdateCommandOutput,
 } from '@aws-sdk/lib-dynamodb'
-import { DocumentClient } from './bootstrap.test'
+import { DocumentClient } from './bootstrap.test.js'
 
 const omit = <O extends Record<string, unknown>, K extends (keyof O)[]>(
   obj: O,

--- a/src/__tests__/utils.unit.test.ts
+++ b/src/__tests__/utils.unit.test.ts
@@ -1,4 +1,4 @@
-import { toBool, hasValue, error } from '../lib/utils'
+import { toBool, hasValue, error } from '../lib/utils.js'
 
 describe('utility functions', () => {
   test('toBool', () => {

--- a/src/__tests__/validateTypes.unit.test.ts
+++ b/src/__tests__/validateTypes.unit.test.ts
@@ -1,5 +1,5 @@
-import { toDynamoBigInt } from '../lib/utils'
-import validateTypes from '../lib/validateTypes'
+import { toDynamoBigInt } from '../lib/utils.js'
+import validateTypes from '../lib/validateTypes.js'
 
 describe('validateTypes', () => {
   it('validates string', async () => {

--- a/src/classes/Entity/Entity.ts
+++ b/src/classes/Entity/Entity.ts
@@ -22,19 +22,19 @@ import type {
 import cloneDeep from 'deep-copy'
 import type { A, B, O } from 'ts-toolbelt'
 
-import parseEntity from '../../lib/parseEntity'
-import validateTypes from '../../lib/validateTypes'
-import normalizeData from '../../lib/normalizeData'
-import formatItem from '../../lib/formatItem'
-import getKey from '../../lib/getKey'
-import parseConditions from '../../lib/expressionBuilder'
-import parseProjections from '../../lib/projectionBuilder'
-import { error, transformAttr, isEmpty, If, FirstDefined, Compute } from '../../lib/utils'
+import parseEntity from '../../lib/parseEntity.js'
+import validateTypes from '../../lib/validateTypes.js'
+import normalizeData from '../../lib/normalizeData.js'
+import formatItem from '../../lib/formatItem.js'
+import getKey from '../../lib/getKey.js'
+import parseConditions from '../../lib/expressionBuilder.js'
+import parseProjections from '../../lib/projectionBuilder.js'
+import { error, transformAttr, isEmpty, If, FirstDefined, Compute } from '../../lib/utils.js'
 import {
   ATTRIBUTE_VALUES_LIST_DEFAULT_KEY,
   ATTRIBUTE_VALUES_LIST_DEFAULT_VALUE,
-} from '../../constants'
-import type { ScanOptions, TableDef } from '../Table'
+} from '../../constants.js'
+import type { ScanOptions, TableDef } from '../Table/types.js'
 import type {
   $GetOptions,
   $PutOptions,
@@ -61,7 +61,7 @@ import type {
   Writable,
   Readonly,
   $PutBatchOptions, AttributeMap,
-} from './types'
+} from './types.js'
 
 class Entity<Name extends string = string,
   // Name is used to detect Entity instances (new Entity(...)) vs Entity type (const e: Entity = ...)

--- a/src/classes/Entity/Entity.ts
+++ b/src/classes/Entity/Entity.ts
@@ -19,7 +19,8 @@ import type {
   ScanInput,
   TransactGetItem
 } from '@aws-sdk/client-dynamodb'
-import cloneDeep from 'deep-copy'
+import * as cloneDeep from 'deep-copy'
+
 import type { A, B, O } from 'ts-toolbelt'
 
 import parseEntity from '../../lib/parseEntity.js'
@@ -149,7 +150,7 @@ class Entity<Name extends string = string,
     // we want to prevent mutation of the original entity configuration input but still be able
     // to mutate the original table instance
     entity = {
-      ...cloneDeep(entitySchemaWithoutTable),
+      ...cloneDeep.default(entitySchemaWithoutTable),
       ...(table ? { table } : {}),
     }
 

--- a/src/classes/Entity/deep-copy.d.ts
+++ b/src/classes/Entity/deep-copy.d.ts
@@ -1,0 +1,4 @@
+declare module 'deep-copy' {
+    declare function dcopy<T>(arg: T): T
+    export default dcopy
+}

--- a/src/classes/Entity/index.ts
+++ b/src/classes/Entity/index.ts
@@ -1,3 +1,3 @@
-export { default as default } from './Entity'
-export * from './Entity'
-export * from './types'
+export { default as default } from './Entity.js'
+export * from './Entity.js'
+export * from './types.js'

--- a/src/classes/Entity/types.ts
+++ b/src/classes/Entity/types.ts
@@ -2,9 +2,9 @@ import type { A, B, O, F } from 'ts-toolbelt'
 import { NativeAttributeValue } from '@aws-sdk/util-dynamodb'
 import { ReturnConsumedCapacity, ReturnItemCollectionMetrics } from '@aws-sdk/client-dynamodb'
 
-import type { Compute, FirstDefined, If } from '../../lib/utils'
-import type { DynamoDBKeyTypes, DynamoDBTypes, $QueryOptions, TableDef } from '../Table'
-import Entity from './Entity'
+import type { Compute, FirstDefined, If } from '../../lib/utils.js'
+import type { DynamoDBKeyTypes, DynamoDBTypes, $QueryOptions, TableDef } from '../Table/types.js'
+import Entity from './Entity.js'
 import { UpdateCommandInput } from '@aws-sdk/lib-dynamodb'
 
 export interface EntityConstructor<

--- a/src/classes/Table/Table.ts
+++ b/src/classes/Table/Table.ts
@@ -1,15 +1,16 @@
 import type { A, O } from 'ts-toolbelt'
 
-import { parseTable, ParsedTable } from '../../lib/parseTable'
-import parseFilters from '../../lib/expressionBuilder'
-import validateTypes from '../../lib/validateTypes'
-import Entity, { AttributeMap } from '../Entity'
+import { parseTable, ParsedTable } from '../../lib/parseTable.js'
+import parseFilters from '../../lib/expressionBuilder.js'
+import validateTypes from '../../lib/validateTypes.js'
+import Entity from '../Entity/Entity.js'
+import { AttributeMap } from '../Entity/types.js'
 import {
   default as parseProjections,
   ProjectionAttributes,
   ProjectionAttributesTable,
-} from '../../lib/projectionBuilder'
-import type { ParsedEntity } from '../../lib/parseEntity'
+} from '../../lib/projectionBuilder.js'
+import type { ParsedEntity } from '../../lib/parseEntity.js'
 import type {
   BatchGetOptions,
   BatchGetParamsMeta,
@@ -23,9 +24,9 @@ import type {
   transactGetParamsOptions,
   TransactWriteOptions,
   transactWriteParamsOptions,
-} from './types'
+} from './types.js'
 
-import { error, conditionError, If, Compute } from '../../lib/utils'
+import { error, conditionError, If, Compute } from '../../lib/utils.js'
 import {
   BatchGetCommand,
   BatchGetCommandInput, BatchWriteCommand,

--- a/src/classes/Table/index.ts
+++ b/src/classes/Table/index.ts
@@ -1,3 +1,3 @@
-export { default as default } from './Table'
-export * from './Table'
-export * from './types'
+export { default as default } from './Table.js'
+export * from './Table.js'
+export * from './types.js'

--- a/src/classes/Table/types.ts
+++ b/src/classes/Table/types.ts
@@ -2,10 +2,10 @@ import { ReturnConsumedCapacity, ReturnItemCollectionMetrics, Select } from '@aw
 import { DynamoDBDocumentClient, ScanCommandInput, TransactGetCommandInput } from '@aws-sdk/lib-dynamodb'
 import type { A, O } from 'ts-toolbelt'
 
-import type { ProjectionAttributes } from '../../lib/projectionBuilder'
-import type { FilterExpressions } from '../../lib/expressionBuilder'
-import type { $ReadOptions, ConditionsOrFilters } from '../Entity'
-import type Table from './Table'
+import type { ProjectionAttributes } from '../../lib/projectionBuilder.js'
+import type { FilterExpressions } from '../../lib/expressionBuilder.js'
+import type { $ReadOptions, ConditionsOrFilters } from '../Entity/types.js'
+import type Table from './Table.js'
 
 export interface TableConstructor<
   Name extends string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import Table from './classes/Table'
-import Entity from './classes/Entity'
+import Table from './classes/Table/Table.js'
+import Entity from './classes/Entity/Entity.js'
 import type {
   GetOptions,
   QueryOptions,
@@ -8,7 +8,7 @@ import type {
   UpdateOptions,
   EntityItem,
   InferEntityItem
-} from './classes/Entity'
+} from './classes/Entity/types.js'
 
 export {
   Table,

--- a/src/lib/checkAttribute.ts
+++ b/src/lib/checkAttribute.ts
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { error } from './utils'
+import { error } from './utils.js'
 
 // Check attribute against attribute set
 export default (attr: string, attrs: any): string => {

--- a/src/lib/expressionBuilder.ts
+++ b/src/lib/expressionBuilder.ts
@@ -9,9 +9,9 @@
 
 import { A } from 'ts-toolbelt'
 
-import checkAttribute from './checkAttribute'
-import { error, toDynamoBigInt } from './utils'
-import { TableDef } from '../classes/Table'
+import checkAttribute from './checkAttribute.js'
+import { error, toDynamoBigInt } from './utils.js'
+import { TableDef } from '../classes/Table/types.js'
 
 interface AttrRef {
   attr: string

--- a/src/lib/formatItem.ts
+++ b/src/lib/formatItem.ts
@@ -5,9 +5,9 @@
  */
 
 import type { NativeAttributeValue, NativeScalarAttributeValue, NumberValue } from '@aws-sdk/util-dynamodb'
-import type { PureAttributeDefinition } from '../classes/Entity'
-import validateTypes from './validateTypes'
-import type { Linked } from './parseEntity'
+import type { PureAttributeDefinition } from '../classes/Entity/types.js'
+import validateTypes from './validateTypes.js'
+import type { Linked } from './parseEntity.js'
 
 // Convert from DocumentClient values, which may be wrapped sets or numbers,
 // into normal TS values.

--- a/src/lib/getKey.ts
+++ b/src/lib/getKey.ts
@@ -4,8 +4,8 @@
  * @license MIT
  */
 
-import validateTypes from './validateTypes'
-import { error, transformAttr } from './utils'
+import validateTypes from './validateTypes.js'
+import { error, transformAttr } from './utils.js'
 
 // Get partitionKey/sortKey
 export default () => (

--- a/src/lib/normalizeData.ts
+++ b/src/lib/normalizeData.ts
@@ -7,8 +7,8 @@
 
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb'
 
-import validateTypes from './validateTypes'
-import { error, transformAttr } from './utils'
+import validateTypes from './validateTypes.js'
+import { error, transformAttr } from './utils.js'
 
 // Normalize Data
 export default () => (

--- a/src/lib/parseCompositeKey.ts
+++ b/src/lib/parseCompositeKey.ts
@@ -5,14 +5,14 @@
  */
 import { A, O } from 'ts-toolbelt'
 
-import { error } from './utils'
-import parseMapping from './parseMapping'
+import { error } from './utils.js'
+import parseMapping from './parseMapping.js'
 import {
   CompositeAttributeDefinition,
   PureAttributeDefinition,
   AttributeDefinitions
-} from '../classes/Entity'
-import { TrackingInfo } from './parseEntity'
+} from '../classes/Entity/types.js'
+import { TrackingInfo } from './parseEntity.js'
 
 const parseCompositeKey = <
   ReadonlyAttributeDefinitions extends

--- a/src/lib/parseEntity.ts
+++ b/src/lib/parseEntity.ts
@@ -1,12 +1,12 @@
-import parseEntityAttributes from './parseEntityAttributes'
-import type { TableDef } from '../classes/Table'
+import parseEntityAttributes from './parseEntityAttributes.js'
+import type { TableDef } from '../classes/Table/types.js'
 import type {
   AttributeDefinitions,
   EntityConstructor,
   PureAttributeDefinition,
   Readonly
-} from '../classes/Entity'
-import { error } from './utils'
+} from '../classes/Entity/types.js'
+import { error } from './utils.js'
 
 export interface TrackingInfo {
   fields: string[]

--- a/src/lib/parseEntityAttributes.ts
+++ b/src/lib/parseEntityAttributes.ts
@@ -9,11 +9,11 @@ import {
   AttributeDefinitions,
   PureAttributeDefinition,
   CompositeAttributeDefinition
-} from '../classes/Entity'
-import { TrackingInfo } from './parseEntity'
-import parseMapping from './parseMapping'
-import parseCompositeKey from './parseCompositeKey'
-import { error, typeError, validTypes, isDynamoDbType } from './utils'
+} from '../classes/Entity/types.js'
+import { TrackingInfo } from './parseEntity.js'
+import parseMapping from './parseMapping.js'
+import parseCompositeKey from './parseCompositeKey.js'
+import { error, typeError, validTypes, isDynamoDbType } from './utils.js'
 
 const parseEntityAttributes = <
   ReadonlyAttributeDefinitions extends

--- a/src/lib/parseMapping.ts
+++ b/src/lib/parseMapping.ts
@@ -10,9 +10,9 @@ import {
   SortKeyDefinition,
   GSISortKeyDefinition,
   PureAttributeDefinition
-} from '../classes/Entity'
-import { TrackingInfo } from './parseEntity'
-import { error } from './utils'
+} from '../classes/Entity/types.js'
+import { TrackingInfo } from './parseEntity.js'
+import { error } from './utils.js'
 
 // Parse and validate mapping config
 export default (

--- a/src/lib/parseTable.ts
+++ b/src/lib/parseTable.ts
@@ -1,8 +1,8 @@
 import { A } from 'ts-toolbelt'
 
-import parseAttributes from './parseTableAttributes'
-import { error, hasValue } from './utils'
-import { TableConstructor, TableIndexes } from '../classes/Table'
+import parseAttributes from './parseTableAttributes.js'
+import { error, hasValue } from './utils.js'
+import { TableConstructor, TableIndexes } from '../classes/Table/types.js'
 
 export type ParsedTable = ReturnType<typeof parseTable>
 

--- a/src/lib/parseTableAttributes.ts
+++ b/src/lib/parseTableAttributes.ts
@@ -4,8 +4,8 @@
  * @license MIT
  */
 
-import { TableAttributes, TableAttributeConfig, ParsedTableAttribute } from '../classes/Table'
-import { error, typeError, keyTypeError, isDynamoDbType, isDynamoDbKeyType } from './utils'
+import { TableAttributes, TableAttributeConfig, ParsedTableAttribute } from '../classes/Table/types.js'
+import { error, typeError, keyTypeError, isDynamoDbType, isDynamoDbKeyType } from './utils.js'
 
 // Parse the attributes and verify valid types
 export default (attrs: TableAttributes, partitionKey: string, sortKey: string | null) =>

--- a/src/lib/projectionBuilder.ts
+++ b/src/lib/projectionBuilder.ts
@@ -8,9 +8,9 @@
 
 import { A } from 'ts-toolbelt'
 
-import { TableDef } from '../classes/Table'
-import { error } from './utils'
-import checkAttribute from './checkAttribute'
+import { TableDef } from '../classes/Table/types.js'
+import { error } from './utils.js'
+import checkAttribute from './checkAttribute.js'
 
 // This should be able to parse an array with values,
 // or an object that uses the name of the entity plus an array of values

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 import { A, L } from 'ts-toolbelt'
 
-import { PureAttributeDefinition } from '../classes/Entity'
-import { DynamoDBTypes, DynamoDBKeyTypes } from '../classes/Table'
+import { PureAttributeDefinition } from '../classes/Entity/types.js'
+import { DynamoDBTypes, DynamoDBKeyTypes } from '../classes/Table/types.js'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 
 export const validTypes: DynamoDBTypes[] = [

--- a/src/lib/validateTypes.ts
+++ b/src/lib/validateTypes.ts
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { toBool, hasValue, error, toDynamoBigInt, typeOf, isArrayOfSameType } from './utils'
+import { toBool, hasValue, error, toDynamoBigInt, typeOf, isArrayOfSameType } from './utils.js'
 
 // Performs type validation/coercion
 export default () => (mapping: any, field: any, value: any) => {

--- a/test-d/index.test-d.ts
+++ b/test-d/index.test-d.ts
@@ -1,1 +1,1 @@
-import type * as types from '../dist'
+import type * as types from '../dist/cjs'

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "commonjs",
     "outDir": "dist/cjs"
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"]

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/cjs"
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmitHelpers": true,
+    "outDir": "dist/esm"
   },
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.test-d.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "baseUrl": "src",
     "target": "es2019",
     "rootDir": "src",
-    "moduleResolution": "node",
-    "module": "commonjs",
     "declaration": true,
     "inlineSourceMap": false,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "baseUrl": "src",
     "target": "es2019",
-    "outDir": "dist",
     "rootDir": "src",
     "moduleResolution": "node",
     "module": "commonjs",


### PR DESCRIPTION
This PR adds dual CommonJS and ES Module support to DynamoDB Toolbox.

Issue it resolves: #606 

The changes include the following

- Update `package.json` to include `exports` property to define location to be used for ES imports

```json
"exports": {
    ".": {
      "import": {
        "default": "./dist/esm/index.js",
        "types": "./dist/esm/index.d.ts"
      },
      "require": {
        "default": "./dist/cjs/index.js",
        "types": "./dist/cjs/index.d.ts"
      }
    }
  },
```

-  Update `package.json` to set default module type to `module`

```json
  "types": "module"
```

- Create a `tsconfig.esm.json` file with ES module specify TypeScript settings

- Rename `tsconfig.build.json` to `tsconfig.cjs.json` and add CommonJS setting for TypeScript

- Update root `tsconfig.json` to use ES modules by default

- Update all `.ts` files to use explicit `.js` imports in accordance with the ES Module spec and Node implementation. Reference [https://www.totaltypescript.com/relative-import-paths-need-explicit-file-extensions-in-ecmascript-imports](https://www.totaltypescript.com/relative-import-paths-need-explicit-file-extensions-in-ecmascript-imports)

- Rename `jest.config.js` to `jest.config.cjs` to explicitly set it to a CommonJS module as the package default is now `module`

- Update `ts-jest` config in `jest.config.cjs` to `useESM: true` and other ES module required config

- Update all test files to use explicit `.js` imports as required by ES module spec and Node implementation

- Add module declaration `deep-copy.d.ts` for the `deep-copy` module used by `Entity`, as it's existing declaration is not sufficient for ES modules

Apologies for the size of the PR. Unfortunately due to ES modules requiring explicit import of files by `.js` extensions I had to touch almost every file, but I only touched them gently.

The tests run and pass. I've also shipped a version of this to `@antstanley/dynamodb-toolbox` if you want to run it yourself and validate behaviour.

Bundling this version now enables me to use ES modules with DynamoDB Toolbox in my Lambda functions without bundling the AWS SDK v3. 

One side effect I've noticed is the ES module version of DynamoDB Toolbox bundles more efficiently, dropping around 30Kb from my specific bundle.


