### PR TITLE
fix: make default prop the last in exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/esm/index.d.ts"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       },
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       }
     }
   },


### PR DESCRIPTION
Fixes #612 

Webpack requires when using conditional exports that `default` property is the last one in the `exports` property. This resolves that issue.
