### PR TITLE
fix: add dist package.json to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,10 +79,12 @@
   },
   "files": [
     "dist/cjs/index.*",
+    "dist/cjs/package.json",
     "dist/cjs/constants.*",
     "dist/cjs/classes/",
     "dist/cjs/lib/",
     "dist/esm/index.*",
+    "dist/esm/package.json",
     "dist/esm/constants.*",
     "dist/esm/classes/",
     "dist/esm/lib/"


### PR DESCRIPTION
Node.js uses either file extensions or the `"type"` field in `package.json` to determine if files are CommonJS or ES Module files. When we shipped dual module support, `package.json` files were placed in both `dist/esm` and `dist/cjs` with the correct `"type"` property. This would enable consumers of the library to correctly interpret what type of module system the files were using. 

The problem is that we did not add these `dist` specific sub `package.json` files to the `files` property of the root `package.json` so they were never published. This led to Node assuming all files were ESM, even the ones in `dist/cjs`.

This leads to errors for folks trying to use CommonJs. This PR adds those files into the `files` property to resolve this issue.

Resolves #615 