### PR TITLE
[V1] Improve types for build method

### DIFF
--- a/src/v1/entity/class.ts
+++ b/src/v1/entity/class.ts
@@ -1,16 +1,6 @@
 import type { Schema } from 'v1/schema'
 import type { TableV2, PrimaryKey } from 'v1/table'
-import type {
-  PutItemCommand,
-  GetItemCommand,
-  DeleteItemCommand,
-  UpdateItemCommand
-} from 'v1/commands'
 import type { KeyInput } from 'v1/commands/types'
-import type { PutItemCommandClass } from 'v1/commands/putItem/command'
-import type { GetItemCommandClass } from 'v1/commands/getItem/command'
-import type { DeleteItemCommandClass } from 'v1/commands/deleteItem/command'
-import type { UpdateItemCommandClass } from 'v1/commands/updateItem/command'
 import type { EntityCommand } from 'v1/commands/class'
 import type { If } from 'v1/types/if'
 import { DynamoDBToolboxError } from 'v1/errors'
@@ -50,21 +40,9 @@ export class EntityV2<
   public computeKey?: (
     keyInput: Schema extends SCHEMA ? any : KeyInput<SCHEMA>
   ) => PrimaryKey<TABLE>
-  // TODO: Maybe there's a way not to have to list all commands here
-  // (use COMMAND_CLASS somehow) but I haven't found it yet
   public build: <COMMAND_CLASS extends typeof EntityCommand = typeof EntityCommand>(
     commandClass: COMMAND_CLASS
-  ) => string extends NAME
-    ? any
-    : COMMAND_CLASS extends PutItemCommandClass
-    ? PutItemCommand<this>
-    : COMMAND_CLASS extends GetItemCommandClass
-    ? GetItemCommand<this>
-    : COMMAND_CLASS extends DeleteItemCommandClass
-    ? DeleteItemCommand<this>
-    : COMMAND_CLASS extends UpdateItemCommandClass
-    ? UpdateItemCommand<this>
-    : EntityCommand<this>
+  ) => InstanceType<COMMAND_CLASS>
 
   /**
    * Define an Entity for a given table

--- a/src/v1/table/class.ts
+++ b/src/v1/table/class.ts
@@ -1,10 +1,6 @@
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb'
 
 import type { TableCommand } from 'v1/commands/class'
-import type { ScanCommand } from 'v1/commands'
-import type { ScanCommandClass } from 'v1/commands/scan/command'
-import type { QueryCommand } from 'v1/commands'
-import type { QueryCommandClass } from 'v1/commands/query/command'
 import type { NarrowObject, NarrowObjectRec } from 'v1/types/narrowObject'
 import { isString } from 'v1/utils/validation/isString'
 
@@ -24,17 +20,9 @@ export class TableV2<
   public entityAttributeSavedAs: ENTITY_ATTRIBUTE_SAVED_AS
 
   public getName: () => string
-  // TODO: Maybe there's a way not to have to list all commands here
-  // (use TABLE_COMMAND_CLASS somehow) but I haven't found it yet
   public build: <TABLE_COMMAND_CLASS extends typeof TableCommand = typeof TableCommand>(
     tableCommandClass: TABLE_COMMAND_CLASS
-  ) => Key extends PARTITION_KEY
-    ? any
-    : TABLE_COMMAND_CLASS extends ScanCommandClass
-    ? ScanCommand<this>
-    : TABLE_COMMAND_CLASS extends QueryCommandClass
-    ? QueryCommand<this>
-    : TableCommand<this>
+  ) => InstanceType<TABLE_COMMAND_CLASS>
 
   /**
    * Define a Table


### PR DESCRIPTION
The `build` method in the `Table` and `Entity` class have a huge if/else structure.
[edit] This PR replaces them by the [`InstanceType`](https://www.typescriptlang.org/docs/handbook/utility-types.html#instancetypetype) utility type but it's not restrictive enough