### PR TITLE
Add missing type: ParseAttributes, to satisfy esm typescript build issue in consuming project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,17 +7,19 @@ import type {
   DeleteOptions,
   UpdateOptions,
   EntityItem,
-  InferEntityItem
+  InferEntityItem,
+  ParseAttributes
 } from './classes/Entity/types.js'
 
-export {
-  Table,
-  Entity,
+export { Table, Entity }
+
+export type {
   GetOptions,
   QueryOptions,
   PutOptions,
   DeleteOptions,
   UpdateOptions,
   EntityItem,
-  InferEntityItem
+  InferEntityItem,
+  ParseAttributes
 }


### PR DESCRIPTION
fixes #631

I have also encountered this issue (Typescript error: TS2742) while converting a data access module I have to Typescript. This module is an NPM dependency in other repos, so I need the typescript definitions files.

My grasp on Typescript is a little tenuous, But from all that I could read and gather from similar issues and actions taken in other libraries, it seems that exporting the additional types is necessary. 

As far as I can see the only additional type needed in the end was `ParseAttributes`, This addition has allowed me to build my project with Typescript and use it. 

Existing tests continue to pass. I can't see any other side effects, but please let me know if there is another approach or if this change is undesirable.

A minimal repo demonstrating the issue: https://github.com/whahoo/dynamodb_TS2742_example

