### PR TITLE
Don't throw for undefined dependsOn attributes in Index key fields

### DIFF
--- a/src/__tests__/normalizeData.unit.test.ts
+++ b/src/__tests__/normalizeData.unit.test.ts
@@ -99,7 +99,7 @@ describe('normalizeData', () => {
 
   it('should not fail for GSI keys', () => {
 
-    const indexedStatus = ['AVAILABLE', 'PENDING'];
+    const indexedStatus = ['AVAILABLE', 'PENDING']
 
     const ent = new Entity({
       name: 'Test',

--- a/src/lib/normalizeData.ts
+++ b/src/lib/normalizeData.ts
@@ -85,7 +85,9 @@ export default () => (
         const map = dependsOn(defaultMap, attr)
         defaultMap = map
       } catch (e) {
-        if (throwOnMissingNonPartitionRequiredProperties && e instanceof DependsOnUndefined && (schema[attr].partitionKey || schema[attr].sortKey || schema[attr].required)) {
+        if (throwOnMissingNonPartitionRequiredProperties 
+          && e instanceof DependsOnUndefined 
+          && (schema[attr].partitionKey === true || schema[attr].sortKey === true || schema[attr].required)) {
           throw new Error(`Required field '${attr}' depends on attribute(s), one or more of which can't be resolved (${schema[attr].dependsOn})`)
         }
         delete defaultMap[attr]


### PR DESCRIPTION
Proposed solution for : https://github.com/jeremydaly/dynamodb-toolbox/issues/739

Isolate key check to table Partition Key and Sort Keys only
