### PR TITLE
Document removing nested attribute from a 'map'

### DIFF
--- a/docs/docs/6-v0/3-entity/3-methods.md
+++ b/docs/docs/6-v0/3-entity/3-methods.md
@@ -261,6 +261,7 @@ await MyEntity.update({
       title: 'Developer', // update metadata.title
       'contact.name': 'Jane Smith', // update metadata.contact.name
       'contact.addresses[0]': '123 Main Street' // update the first array item in metadata.contact.addresses
+      'contact.phone': null // remove metadata.contact.phone field
     }
   }
 })


### PR DESCRIPTION
Figuring this out took me way longer than I'd like to admit so I've added a simple example on how to remove a nested attribute from a map.. 😉

Also, this seems to work regardless of the `removeNullAttributes` table property state - it removes the attribute even if it's set to `false`